### PR TITLE
feat: send second reminder when task is not submitted

### DIFF
--- a/grove-web/src/api/client.ts
+++ b/grove-web/src/api/client.ts
@@ -6,26 +6,33 @@ const API_BASE_URL = import.meta.env.VITE_API_URL || '';
 export interface ApiError {
   status: number;
   message: string;
+  // Parsed JSON body if available
+  data?: unknown;
 }
 
-// Try to extract error message from response body
-async function extractErrorMessage(response: Response): Promise<string> {
+type ErrorPayload = { message: string; data?: unknown };
+
+// Try to extract error message (and JSON body) from response
+async function extractErrorPayload(response: Response): Promise<ErrorPayload> {
   try {
     const text = await response.text();
     if (text) {
       try {
         const json = JSON.parse(text);
         // Check common error message fields
-        return json.message || json.error || json.detail || text;
+        return {
+          message: json.message || json.error || json.detail || text,
+          data: json,
+        };
       } catch {
         // Not JSON, return raw text
-        return text;
+        return { message: text };
       }
     }
   } catch {
     // Ignore extraction errors
   }
-  return response.statusText;
+  return { message: response.statusText };
 }
 
 export class ApiClient {
@@ -44,10 +51,11 @@ export class ApiClient {
     });
 
     if (!response.ok) {
-      const message = await extractErrorMessage(response);
+      const payload = await extractErrorPayload(response);
       throw {
         status: response.status,
-        message,
+        message: payload.message,
+        data: payload.data,
       } as ApiError;
     }
 
@@ -64,10 +72,11 @@ export class ApiClient {
     });
 
     if (!response.ok) {
-      const message = await extractErrorMessage(response);
+      const payload = await extractErrorPayload(response);
       throw {
         status: response.status,
-        message,
+        message: payload.message,
+        data: payload.data,
       } as ApiError;
     }
 
@@ -84,10 +93,11 @@ export class ApiClient {
     });
 
     if (!response.ok) {
-      const message = await extractErrorMessage(response);
+      const payload = await extractErrorPayload(response);
       throw {
         status: response.status,
-        message,
+        message: payload.message,
+        data: payload.data,
       } as ApiError;
     }
 
@@ -103,10 +113,11 @@ export class ApiClient {
     });
 
     if (!response.ok) {
-      const message = await extractErrorMessage(response);
+      const payload = await extractErrorPayload(response);
       throw {
         status: response.status,
-        message,
+        message: payload.message,
+        data: payload.data,
       } as ApiError;
     }
 
@@ -128,10 +139,11 @@ export class ApiClient {
     });
 
     if (!response.ok) {
-      const message = await extractErrorMessage(response);
+      const payload = await extractErrorPayload(response);
       throw {
         status: response.status,
-        message,
+        message: payload.message,
+        data: payload.data,
       } as ApiError;
     }
 

--- a/grove-web/src/api/tasks.ts
+++ b/grove-web/src/api/tasks.ts
@@ -194,9 +194,14 @@ export async function createTask(
 /**
  * Archive a task
  */
-export async function archiveTask(projectId: string, taskId: string): Promise<TaskResponse> {
+export async function archiveTask(
+  projectId: string,
+  taskId: string,
+  options?: { force?: boolean }
+): Promise<TaskResponse> {
+  const force = options?.force ?? false;
   return apiClient.post<undefined, TaskResponse>(
-    `/api/v1/projects/${projectId}/tasks/${taskId}/archive`
+    `/api/v1/projects/${projectId}/tasks/${taskId}/archive?force=${force}`
   );
 }
 

--- a/grove-web/src/components/Dialogs/ConfirmDialog.tsx
+++ b/grove-web/src/components/Dialogs/ConfirmDialog.tsx
@@ -6,7 +6,7 @@ import { Button } from "../ui";
 interface ConfirmDialogProps {
   isOpen: boolean;
   title: string;
-  message: string;
+  message: React.ReactNode;
   confirmLabel?: string;
   cancelLabel?: string;
   variant?: "danger" | "warning" | "info";
@@ -96,7 +96,11 @@ export function ConfirmDialog({
 
               {/* Content */}
               <div className="px-5 py-4">
-                <p className="text-sm text-[var(--color-text-muted)]">{message}</p>
+                {typeof message === "string" ? (
+                  <p className="text-sm text-[var(--color-text-muted)] whitespace-pre-line">{message}</p>
+                ) : (
+                  <div className="text-sm text-[var(--color-text-muted)]">{message}</div>
+                )}
               </div>
 
               {/* Actions */}

--- a/src/dialogs.rs
+++ b/src/dialogs.rs
@@ -153,9 +153,14 @@ mod tests {
         state.show_new_task_dialog = true;
         state.new_task_input = "test".to_string();
         state.show_help = true;
-        state.confirm_dialog = Some(ConfirmType::ArchiveUnmerged {
+        state.confirm_dialog = Some(ConfirmType::ArchiveConfirm {
             task_name: "Test Task".to_string(),
             branch: "test-branch".to_string(),
+            target: "main".to_string(),
+            worktree_dirty: true,
+            branch_merged: true,
+            dirty_check_failed: false,
+            merge_check_failed: false,
         });
         state.input_confirm_dialog = Some(InputConfirmData::new(
             "Test Task".to_string(),
@@ -194,9 +199,14 @@ mod tests {
         let mut state = DialogState::new();
         assert!(!state.has_active_dialog());
 
-        state.confirm_dialog = Some(ConfirmType::ArchiveUnmerged {
+        state.confirm_dialog = Some(ConfirmType::ArchiveConfirm {
             task_name: "Test".to_string(),
             branch: "test".to_string(),
+            target: "main".to_string(),
+            worktree_dirty: false,
+            branch_merged: false,
+            dirty_check_failed: false,
+            merge_check_failed: false,
         });
         assert!(state.has_active_dialog());
     }


### PR DESCRIPTION
### Description
本 PR 优化了 TUI和GUI 模式下的 Archive 确认流程

#### 主要改动
*  **风险可视化**：新增了检测到任务分支未合并时，Archive时需要用户的二次确认流程，降低误点导致工作丢失风险，并且补齐了Gui模式下Archive无确认弹窗的空白，整体对齐TUI。
*   **结构化确认弹窗**：重构了 Archive 确认弹窗，将原本的纯文本提示改为结构化卡片展示（包含 Task Name, Branch, Target）。
 *   **Merge 后流程**：统一了 Merge 成功后询问是否 Archive 的弹窗样式，使其与整体设计语言保持一致，并优化了按钮文案（Archive / Later）。


### Screenshots

<img width="1554" height="1142" alt="20260212225618_12049_19" src="https://github.com/user-attachments/assets/97c2b94f-d33f-47ac-a582-00096876847b" />



