### PR TITLE
feat: add preview model for review

### DIFF
--- a/grove-web/src/components/Review/diffTheme.css
+++ b/grove-web/src/components/Review/diffTheme.css
@@ -217,9 +217,8 @@
 
 .diff-file-header {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
+  flex-direction: column;
+  align-items: stretch;
   background: var(--color-bg-secondary);
   border-bottom: 1px solid var(--color-border);
   border-top: 1px solid var(--color-border);
@@ -227,6 +226,44 @@
   top: 0;
   z-index: 5;
   font-size: 13px;
+}
+
+.diff-file-header-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+}
+
+.diff-file-preview-mode {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 8px 16px;
+  border-top: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-bg-secondary) 92%, var(--color-bg) 8%);
+}
+
+.diff-file-preview-mode button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0;
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  transition: color 0.15s;
+}
+
+.diff-file-preview-mode button:hover {
+  color: var(--color-text);
+}
+
+.diff-file-preview-mode button.active {
+  color: var(--color-text);
 }
 
 .diff-file-path {
@@ -1317,6 +1354,83 @@ td.diff-code.diff-line-highlighted::before {
   font-size: 12px;
 }
 
+.preview-diff-blocks {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.preview-diff-block {
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--color-bg-secondary);
+}
+
+.preview-diff-block.context {
+  border-left: 4px solid var(--color-border);
+}
+
+.preview-diff-block.insert {
+  border-left: 4px solid var(--color-success);
+}
+
+.preview-diff-block.delete {
+  border-left: 4px solid var(--color-error);
+}
+
+.preview-diff-block-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-tertiary);
+}
+
+.preview-diff-badge {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  background: var(--color-bg);
+  flex-shrink: 0;
+}
+
+.preview-diff-badge.insert {
+  color: var(--color-success);
+  border-color: color-mix(in srgb, var(--color-success) 40%, var(--color-border));
+}
+
+.preview-diff-badge.delete {
+  color: var(--color-error);
+  border-color: color-mix(in srgb, var(--color-error) 40%, var(--color-border));
+}
+
+.preview-diff-hunk {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.preview-diff-block.delete .markdown-content,
+.preview-diff-block.delete h1,
+.preview-diff-block.delete h2,
+.preview-diff-block.delete h3,
+.preview-diff-block.delete h4,
+.preview-diff-block.delete h5,
+.preview-diff-block.delete h6,
+.preview-diff-block.delete p,
+.preview-diff-block.delete li,
+.preview-diff-block.delete code {
+  color: var(--color-text-muted) !important;
+  text-decoration: line-through;
+}
+
 /* ============================================================================
    Conversation sidebar (right panel)
    ============================================================================ */
@@ -2271,8 +2385,16 @@ td.diff-code.diff-line-highlighted::before {
 
   /* --- File header --- */
   .diff-file-header {
+    font-size: 12px;
+  }
+  .diff-file-header-top {
     padding: 6px 10px;
     gap: 6px;
+    flex-wrap: wrap;
+  }
+  .diff-file-preview-mode {
+    padding: 6px 10px;
+    gap: 12px;
     flex-wrap: wrap;
   }
   .diff-file-header-right {


### PR DESCRIPTION
# PR 描述：feat: add preview mode

## 现状
- Review 页面只有 diff 视图与会话侧栏，缺少“右侧预览面板”，对于markdown这类富文本的可读性较差，影响review时的观感体验。

## 目的
- 在 Code Review 页面提供 Markdown 的即时预览能力，提升评审效率与可读性。
- 同时保留原始 diff 能力，并支持并排/切换查看。


## 用户动线
1. 打开任意任务的 Review 页面。
2. 点击工具栏的“眼睛”按钮打开 Preview 侧栏。
3. 选择一个 `.md / .markdown` 文件：
   - 右侧展示渲染后的 Markdown 预览（最新内容）。
4. 若选择非 Markdown 文件：
   - 右侧显示该文件的 diff 预览。
5. 可拖拽 Preview 边界调整宽度，或点击 “Hide/Show” 切换原始 diff 区域显示。

## 变更动作
- 新增 Preview 侧栏（可显示/隐藏），作为 Diff 内容的右侧分栏。
- Markdown 文件在 Preview 侧栏内渲染（使用 MarkdownRenderer），显示“最新内容”，非 Markdown 文件在 Preview 侧栏内复用 DiffFileView 进行预览。
- Preview 侧栏支持拖拽调整宽度，并持久化宽度到 localStorage。
- 增加“Hide/Show raw content”按钮，可切换是否显示主 diff 内容。
- 新增 Preview 工具栏按钮（眼睛图标）用于快速开关预览侧栏。


<img width="2974" height="1722" alt="image" src="https://github.com/user-attachments/assets/df815ace-4c69-4d58-b008-b5ac9cb26188" />
