### PR TITLE
feat: web-based folder picker for headless / remote Grove instances

### DIFF
--- a/grove-web/src/api/projects.ts
+++ b/grove-web/src/api/projects.ts
@@ -300,6 +300,8 @@ export async function updateMemory(id: string, content: string): Promise<{ conte
 
 export interface FolderEntry {
   name: string;
+  /** Absolute path of this entry — use this for navigation, don't join client-side. */
+  path: string;
   is_git_repo: boolean;
 }
 

--- a/grove-web/src/api/projects.ts
+++ b/grove-web/src/api/projects.ts
@@ -293,3 +293,32 @@ export async function getMemory(id: string): Promise<{ content: string }> {
 export async function updateMemory(id: string, content: string): Promise<{ content: string }> {
   return apiClient.put<{ content: string }, { content: string }>(`/api/v1/projects/${id}/memory`, { content });
 }
+
+// ============================================================================
+// Folder picker (web fallback for native browse_folder)
+// ============================================================================
+
+export interface FolderEntry {
+  name: string;
+  is_git_repo: boolean;
+}
+
+export interface ListFolderResponse {
+  /** Absolute path that was listed. */
+  path: string;
+  /** Parent dir, or null at filesystem root. */
+  parent: string | null;
+  /** Sub-directories (files + dotfiles excluded), sorted case-insensitively. */
+  entries: FolderEntry[];
+  /** User's home dir on the Grove server, for the "Home" button. */
+  home: string | null;
+}
+
+/**
+ * List sub-directories under `path` for the web folder picker.
+ * Throws on absolute-path violations, .. traversal, missing path, or non-dir.
+ */
+export async function listFolder(path: string): Promise<ListFolderResponse> {
+  const qs = new URLSearchParams({ path });
+  return apiClient.get<ListFolderResponse>(`/api/v1/folders/list?${qs.toString()}`);
+}

--- a/grove-web/src/components/Projects/AddProjectDialog.tsx
+++ b/grove-web/src/components/Projects/AddProjectDialog.tsx
@@ -76,6 +76,7 @@ export function AddProjectDialog({
       setGitName("");
       setGitNameTouched(false);
       setError("");
+      setPickerOpen(null);
     }
     prevIsOpenRef.current = isOpen;
   }, [isOpen, initialMode]);
@@ -140,6 +141,7 @@ export function AddProjectDialog({
       if (data.path) {
         setPath(data.path);
         if (!existingNameTouched) setExistingName(data.path.split("/").pop() || "");
+        setError("");
       } else {
         // Native dialog unavailable (headless host) — open web picker.
         setPickerOpen("existing");
@@ -156,6 +158,7 @@ export function AddProjectDialog({
       const data = await apiClient.get<{ path: string | null }>("/api/v1/browse-folder");
       if (data.path) {
         setParentDir(data.path);
+        setError("");
       } else {
         setPickerOpen("parent");
       }
@@ -551,6 +554,7 @@ export function AddProjectDialog({
         } else if (pickerOpen === "parent") {
           setParentDir(p);
         }
+        setError("");
         setPickerOpen(null);
       }}
       title={pickerOpen === "parent" ? "Select Parent Directory" : "Select Project Folder"}

--- a/grove-web/src/components/Projects/AddProjectDialog.tsx
+++ b/grove-web/src/components/Projects/AddProjectDialog.tsx
@@ -134,8 +134,22 @@ export function AddProjectDialog({
   const displayedExistingName = existingNameTouched ? existingName : deriveNameFromPath(path);
   const displayedGitName = gitNameTouched ? gitName : deriveNameFromGitUrl(gitUrl);
 
+  // In remote/mobile mode the native dialog would open on the server's
+  // physical screen (invisible to the remote user) and `Command::output()`
+  // blocks until someone dismisses it on that screen — so the request hangs
+  // and our "fallback when null/throw" path never triggers. Skip the native
+  // call entirely in that mode and go straight to the web picker.
+  // `window.__GROVE_REMOTE__` is set by AuthGate when `/api/v1/auth/info`
+  // reports either `remote: true` or `required: true`.
+  const isRemoteMode = (): boolean =>
+    (window as unknown as Record<string, unknown>).__GROVE_REMOTE__ === true;
+
   // Use apiClient (not raw fetch) so HMAC headers are attached in mobile mode.
   const handleBrowseExisting = async () => {
+    if (isRemoteMode()) {
+      setPickerOpen("existing");
+      return;
+    }
     try {
       const data = await apiClient.get<{ path: string | null }>("/api/v1/browse-folder");
       if (data.path) {
@@ -154,6 +168,10 @@ export function AddProjectDialog({
   };
 
   const handleBrowseParent = async () => {
+    if (isRemoteMode()) {
+      setPickerOpen("parent");
+      return;
+    }
     try {
       const data = await apiClient.get<{ path: string | null }>("/api/v1/browse-folder");
       if (data.path) {

--- a/grove-web/src/components/Projects/AddProjectDialog.tsx
+++ b/grove-web/src/components/Projects/AddProjectDialog.tsx
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 import { X, Plus, FolderOpen, GitBranch, Sparkles, Code2, Globe } from "lucide-react";
 import { Button } from "../ui";
 import { DialogShell } from "../ui/DialogShell";
+import { FolderTreePickerDialog } from "./FolderTreePickerDialog";
 import { useIsMobile } from "../../hooks";
 import { apiClient } from "../../api/client";
 
@@ -54,6 +55,8 @@ export function AddProjectDialog({
 
   const [error, setError] = useState("");
   const { isMobile } = useIsMobile();
+
+  const [pickerOpen, setPickerOpen] = useState<null | "existing" | "parent">(null);
 
   const prevIsOpenRef = useRef(isOpen);
 
@@ -136,11 +139,15 @@ export function AddProjectDialog({
       const data = await apiClient.get<{ path: string | null }>("/api/v1/browse-folder");
       if (data.path) {
         setPath(data.path);
-        setError("");
+        if (!existingNameTouched) setExistingName(data.path.split("/").pop() || "");
+      } else {
+        // Native dialog unavailable (headless host) — open web picker.
+        setPickerOpen("existing");
       }
     } catch (err) {
       console.error("Failed to browse folder:", err);
-      setError("Failed to open folder picker");
+      // Network/API failure — fall back to web picker rather than dead-ending.
+      setPickerOpen("existing");
     }
   };
 
@@ -149,11 +156,12 @@ export function AddProjectDialog({
       const data = await apiClient.get<{ path: string | null }>("/api/v1/browse-folder");
       if (data.path) {
         setParentDir(data.path);
-        setError("");
+      } else {
+        setPickerOpen("parent");
       }
     } catch (err) {
       console.error("Failed to browse folder:", err);
-      setError("Failed to open folder picker");
+      setPickerOpen("parent");
     }
   };
 
@@ -244,6 +252,7 @@ export function AddProjectDialog({
   };
 
   return (
+    <>
     <DialogShell isOpen={isOpen} onClose={resetAndClose}>
       <div
         onKeyDown={handleKeyDown}
@@ -532,6 +541,21 @@ export function AddProjectDialog({
         </div>
       </div>
     </DialogShell>
+    <FolderTreePickerDialog
+      isOpen={pickerOpen !== null}
+      onClose={() => setPickerOpen(null)}
+      onSelect={(p) => {
+        if (pickerOpen === "existing") {
+          setPath(p);
+          if (!existingNameTouched) setExistingName(p.split("/").pop() || "");
+        } else if (pickerOpen === "parent") {
+          setParentDir(p);
+        }
+        setPickerOpen(null);
+      }}
+      title={pickerOpen === "parent" ? "Select Parent Directory" : "Select Project Folder"}
+    />
+    </>
   );
 }
 

--- a/grove-web/src/components/Projects/FolderTreePickerDialog.tsx
+++ b/grove-web/src/components/Projects/FolderTreePickerDialog.tsx
@@ -84,20 +84,33 @@ export function FolderTreePickerDialog({
 
   if (!isOpen) return null;
 
-  // Build breadcrumb segments. data.path = "/home/dev/projects" → [{label:"/", path:""}, {label:"home", path:"/home"}, ...]
-  const crumbs = data
-    ? data.path
-        .split("/")
-        .filter(Boolean)
-        .reduce<Array<{ label: string; path: string }>>(
-          (acc, seg) => {
-            const prev = acc.length ? acc[acc.length - 1].path : "";
-            acc.push({ label: seg, path: `${prev}/${seg}` });
-            return acc;
-          },
-          [{ label: "/", path: "" }],
-        )
-    : [];
+  // Detect path separator from the response. Windows paths use '\' and start
+  // with a drive letter (e.g. "C:\Users\dev"); Unix uses '/' with a synthetic
+  // root. We assume paths don't mix separators within a single response.
+  const sep: "/" | "\\" = data?.path.includes("\\") ? "\\" : "/";
+
+  // Build breadcrumb segments cross-platform.
+  // Linux "/home/dev"   → [{/, /}, {home, /home}, {dev, /home/dev}]
+  // Windows "C:\Users\dev" → [{C:, C:\}, {Users, C:\Users}, {dev, C:\Users\dev}]
+  const crumbs: Array<{ label: string; path: string }> = [];
+  if (data) {
+    const segs = data.path.split(sep).filter(Boolean);
+    if (sep === "/") {
+      crumbs.push({ label: "/", path: "/" });
+    }
+    let acc = "";
+    segs.forEach((seg, i) => {
+      if (sep === "\\" && i === 0) {
+        // First Windows segment is the drive letter; root path is "DRIVE\"
+        acc = `${seg}${sep}`;
+      } else if (sep === "/" && i === 0) {
+        acc = `/${seg}`;
+      } else {
+        acc = `${acc}${sep}${seg}`;
+      }
+      crumbs.push({ label: seg, path: acc });
+    });
+  }
 
   return (
     <DialogShell isOpen={isOpen} onClose={onClose} maxWidth="max-w-2xl">
@@ -139,12 +152,12 @@ export function FolderTreePickerDialog({
             </Button>
             <div className="flex-1 overflow-x-auto text-xs text-[var(--color-text-muted)] whitespace-nowrap">
               {crumbs.map((c, i) => (
-                <span key={c.path || "/"}>
-                  {i > 0 && <span className="mx-1">/</span>}
+                <span key={c.path || sep}>
+                  {i > 0 && <span className="mx-1">{sep}</span>}
                   <button
                     type="button"
                     className="hover:underline hover:text-[var(--color-text)] disabled:opacity-50"
-                    onClick={() => void load(c.path || "/")}
+                    onClick={() => void load(c.path || sep)}
                     disabled={loading}
                   >
                     {c.label}

--- a/grove-web/src/components/Projects/FolderTreePickerDialog.tsx
+++ b/grove-web/src/components/Projects/FolderTreePickerDialog.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useRef, useState } from "react";
+import { Folder, GitBranch, ChevronUp, Home as HomeIcon, Check, X } from "lucide-react";
+import { Button, DialogShell } from "../ui";
+import { listFolder, type ListFolderResponse } from "../../api/projects";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Called with the absolute path the user selected. */
+  onSelect: (path: string) => void;
+  /** Modal title. Default: "Select Folder". */
+  title?: string;
+  /** Starting dir. Default: server's $HOME (probed via root). */
+  initialPath?: string;
+}
+
+/**
+ * Extract a human-readable message from anything thrown by apiClient.
+ * apiClient throws plain object literals {status, message, data}, not Error
+ * instances, so plain `e.message` access requires type narrowing.
+ */
+function extractErrorMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (typeof e === "object" && e !== null && "message" in e) {
+    const msg = (e as { message: unknown }).message;
+    if (typeof msg === "string") return msg;
+  }
+  return String(e);
+}
+
+export function FolderTreePickerDialog({
+  isOpen,
+  onClose,
+  onSelect,
+  title = "Select Folder",
+  initialPath,
+}: Props) {
+  const [data, setData] = useState<ListFolderResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reqIdRef = useRef(0);
+  const prevIsOpenRef = useRef(false);
+
+  const load = async (path: string) => {
+    const myId = ++reqIdRef.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const resp = await listFolder(path);
+      if (reqIdRef.current === myId) setData(resp);
+    } catch (e: unknown) {
+      if (reqIdRef.current === myId) setError(extractErrorMessage(e));
+    } finally {
+      if (reqIdRef.current === myId) setLoading(false);
+    }
+  };
+
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    if (isOpen && !prevIsOpenRef.current) {
+      // close→open transition: initialize browser state
+      if (initialPath) {
+        void load(initialPath);
+      } else {
+        void (async () => {
+          try {
+            const probe = await listFolder("/");
+            await load(probe.home || "/");
+          } catch (e: unknown) {
+            // The probe failed (couldn't list "/"). Race-guard isn't needed
+            // here because this only runs once on open, before any folder
+            // click. Just surface the error.
+            setError(extractErrorMessage(e));
+          }
+        })();
+      }
+    }
+    prevIsOpenRef.current = isOpen;
+  }, [isOpen, initialPath]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  if (!isOpen) return null;
+
+  // Build breadcrumb segments. data.path = "/home/dev/projects" → [{label:"/", path:""}, {label:"home", path:"/home"}, ...]
+  const crumbs = data
+    ? data.path
+        .split("/")
+        .filter(Boolean)
+        .reduce<Array<{ label: string; path: string }>>(
+          (acc, seg) => {
+            const prev = acc.length ? acc[acc.length - 1].path : "";
+            acc.push({ label: seg, path: `${prev}/${seg}` });
+            return acc;
+          },
+          [{ label: "/", path: "" }],
+        )
+    : [];
+
+  return (
+    <DialogShell isOpen={isOpen} onClose={onClose} maxWidth="max-w-2xl">
+      <div className="bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-xl shadow-xl overflow-hidden w-full max-w-[95vw]">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--color-border)]">
+          <h2 className="text-lg font-semibold text-[var(--color-text)]">{title}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="p-1.5 rounded-lg hover:bg-[var(--color-bg-tertiary)] text-[var(--color-text-muted)] transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-4 space-y-3">
+          {/* Toolbar */}
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => data?.parent && void load(data.parent)}
+              disabled={!data?.parent || loading}
+              type="button"
+            >
+              <ChevronUp className="w-4 h-4 mr-1" /> Up
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => data?.home && void load(data.home)}
+              disabled={!data?.home || loading}
+              type="button"
+            >
+              <HomeIcon className="w-4 h-4 mr-1" /> Home
+            </Button>
+            <div className="flex-1 overflow-x-auto text-xs text-[var(--color-text-muted)] whitespace-nowrap">
+              {crumbs.map((c, i) => (
+                <span key={c.path || "/"}>
+                  {i > 0 && <span className="mx-1">/</span>}
+                  <button
+                    type="button"
+                    className="hover:underline hover:text-[var(--color-text)] disabled:opacity-50"
+                    onClick={() => void load(c.path || "/")}
+                    disabled={loading}
+                  >
+                    {c.label}
+                  </button>
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {/* List */}
+          <div className="border border-[var(--color-border)] rounded-md max-h-80 overflow-y-auto bg-[var(--color-bg)]">
+            {loading && (
+              <div className="p-4 text-sm text-[var(--color-text-muted)]">Loading…</div>
+            )}
+            {error && !loading && (
+              <div className="p-4 text-sm text-[var(--color-error)]">{error}</div>
+            )}
+            {data && !loading && !error && data.entries.length === 0 && (
+              <div className="p-4 text-sm text-[var(--color-text-muted)]">
+                No sub-directories.
+              </div>
+            )}
+            {data &&
+              !loading &&
+              !error &&
+              data.entries.map((e) => (
+                <button
+                  key={e.name}
+                  type="button"
+                  onClick={() =>
+                    void load(`${data.path === "/" ? "" : data.path}/${e.name}`)
+                  }
+                  disabled={loading}
+                  className="w-full text-left px-3 py-2 flex items-center gap-2 hover:bg-[var(--color-bg-tertiary)] border-b border-[var(--color-border)] last:border-b-0 text-sm text-[var(--color-text)] disabled:opacity-50"
+                >
+                  <Folder className="w-4 h-4 text-[var(--color-text-muted)] shrink-0" />
+                  <span className="flex-1 truncate">{e.name}</span>
+                  {e.is_git_repo && (
+                    <span className="text-xs text-[var(--color-highlight)] flex items-center gap-1 shrink-0">
+                      <GitBranch className="w-3 h-3" /> git
+                    </span>
+                  )}
+                </button>
+              ))}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 px-5 py-4 bg-[var(--color-bg)] border-t border-[var(--color-border)]">
+          <Button variant="secondary" onClick={onClose} type="button">
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => data && onSelect(data.path)}
+            disabled={!data || loading}
+            type="button"
+          >
+            <Check className="w-4 h-4 mr-1" />
+            Select this folder
+          </Button>
+        </div>
+      </div>
+    </DialogShell>
+  );
+}

--- a/grove-web/src/components/Projects/FolderTreePickerDialog.tsx
+++ b/grove-web/src/components/Projects/FolderTreePickerDialog.tsx
@@ -50,7 +50,10 @@ export function FolderTreePickerDialog({
       const resp = await listFolder(path);
       if (reqIdRef.current === myId) setData(resp);
     } catch (e: unknown) {
-      if (reqIdRef.current === myId) setError(extractErrorMessage(e));
+      if (reqIdRef.current === myId) {
+        setError(extractErrorMessage(e));
+        setData(null);
+      }
     } finally {
       if (reqIdRef.current === myId) setLoading(false);
     }
@@ -64,14 +67,13 @@ export function FolderTreePickerDialog({
         void load(initialPath);
       } else {
         void (async () => {
+          const myId = ++reqIdRef.current;
           try {
             const probe = await listFolder("/");
+            if (reqIdRef.current !== myId) return;
             await load(probe.home || "/");
           } catch (e: unknown) {
-            // The probe failed (couldn't list "/"). Race-guard isn't needed
-            // here because this only runs once on open, before any folder
-            // click. Just surface the error.
-            setError(extractErrorMessage(e));
+            if (reqIdRef.current === myId) setError(extractErrorMessage(e));
           }
         })();
       }
@@ -172,9 +174,7 @@ export function FolderTreePickerDialog({
                 <button
                   key={e.name}
                   type="button"
-                  onClick={() =>
-                    void load(`${data.path === "/" ? "" : data.path}/${e.name}`)
-                  }
+                  onClick={() => void load(e.path)}
                   disabled={loading}
                   className="w-full text-left px-3 py-2 flex items-center gap-2 hover:bg-[var(--color-bg-tertiary)] border-b border-[var(--color-border)] last:border-b-0 text-sm text-[var(--color-text)] disabled:opacity-50"
                 >

--- a/grove-web/src/components/Projects/index.ts
+++ b/grove-web/src/components/Projects/index.ts
@@ -1,1 +1,2 @@
 export { ProjectsPage } from "./ProjectsPage";
+export { FolderTreePickerDialog } from "./FolderTreePickerDialog";

--- a/src/api/handlers/folder.rs
+++ b/src/api/handlers/folder.rs
@@ -135,6 +135,8 @@ pub struct ListFolderQuery {
 #[derive(Debug, Serialize)]
 pub struct FolderEntry {
     pub name: String,
+    /// Absolute path of this entry (parent + name, properly joined).
+    pub path: String,
     pub is_git_repo: bool,
 }
 
@@ -154,6 +156,7 @@ pub struct ListFolderResponse {
 #[derive(Debug)]
 pub enum ListFolderError {
     BadRequest(String),
+    Forbidden(String),
     NotFound(String),
     Internal(String),
 }
@@ -161,7 +164,9 @@ pub enum ListFolderError {
 impl std::fmt::Display for ListFolderError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::BadRequest(m) | Self::NotFound(m) | Self::Internal(m) => f.write_str(m),
+            Self::BadRequest(m) | Self::Forbidden(m) | Self::NotFound(m) | Self::Internal(m) => {
+                f.write_str(m)
+            }
         }
     }
 }
@@ -188,6 +193,9 @@ pub fn list_folder_inner(q: ListFolderQuery) -> Result<ListFolderResponse, ListF
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             return Err(ListFolderError::NotFound("path not found".into()))
         }
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+            return Err(ListFolderError::Forbidden("permission denied".into()))
+        }
         Err(e) => return Err(ListFolderError::Internal(format!("stat failed: {}", e))),
     };
     if !meta.is_dir() {
@@ -195,8 +203,12 @@ pub fn list_folder_inner(q: ListFolderQuery) -> Result<ListFolderResponse, ListF
             "path is not a directory".into(),
         ));
     }
-    let read = std::fs::read_dir(p)
-        .map_err(|e| ListFolderError::Internal(format!("read_dir failed: {}", e)))?;
+    let read = std::fs::read_dir(p).map_err(|e| match e.kind() {
+        std::io::ErrorKind::PermissionDenied => {
+            ListFolderError::Forbidden("permission denied".into())
+        }
+        _ => ListFolderError::Internal(format!("read_dir failed: {}", e)),
+    })?;
     let mut entries: Vec<FolderEntry> = read
         .filter_map(|r| r.ok())
         .filter_map(|de| {
@@ -211,7 +223,11 @@ pub fn list_folder_inner(q: ListFolderQuery) -> Result<ListFolderResponse, ListF
             // try_exists distinguishes "doesn't exist" from "couldn't stat" — the
             // latter (permission denied, etc.) shouldn't false-flag as a git repo.
             let is_git_repo = de.path().join(".git").try_exists().unwrap_or(false);
-            Some(FolderEntry { name, is_git_repo })
+            Some(FolderEntry {
+                name,
+                path: de.path().to_string_lossy().to_string(),
+                is_git_repo,
+            })
         })
         .collect();
     entries.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
@@ -219,7 +235,9 @@ pub fn list_folder_inner(q: ListFolderQuery) -> Result<ListFolderResponse, ListF
         path: raw.to_string(),
         parent: p.parent().map(|pp| pp.to_string_lossy().to_string()),
         entries,
-        home: std::env::var("HOME").ok(),
+        home: std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .ok(),
     })
 }
 
@@ -229,6 +247,7 @@ pub async fn list_folder(
     match list_folder_inner(q) {
         Ok(r) => Ok(Json(r)),
         Err(ListFolderError::BadRequest(msg)) => Err(ApiError::bad_request(&msg)),
+        Err(ListFolderError::Forbidden(msg)) => Err(ApiError::forbidden(&msg)),
         Err(ListFolderError::NotFound(msg)) => Err(ApiError::not_found(&msg)),
         Err(ListFolderError::Internal(msg)) => Err(ApiError::internal(&msg)),
     }
@@ -267,6 +286,7 @@ mod tests {
         assert!(!names.contains(&".hidden"), "dotfiles hidden by default");
         let repo_a = resp.entries.iter().find(|e| e.name == "repo-a").unwrap();
         assert!(repo_a.is_git_repo);
+        assert_eq!(repo_a.path, td.path().join("repo-a").to_string_lossy());
         let plain = resp.entries.iter().find(|e| e.name == "plain-dir").unwrap();
         assert!(!plain.is_git_repo);
         assert_eq!(resp.path, td.path().to_string_lossy());

--- a/src/api/handlers/folder.rs
+++ b/src/api/handlers/folder.rs
@@ -174,7 +174,7 @@ impl std::fmt::Display for ListFolderError {
 /// Pure function for unit-testing. The axum handler wraps this with Result→HTTP.
 pub fn list_folder_inner(q: ListFolderQuery) -> Result<ListFolderResponse, ListFolderError> {
     let raw = q.path.trim();
-    if !raw.starts_with('/') {
+    if !std::path::Path::new(raw).is_absolute() {
         return Err(ListFolderError::BadRequest("path must be absolute".into()));
     }
     // Textual `..` check only — this does NOT defend against symlink-based

--- a/src/api/handlers/folder.rs
+++ b/src/api/handlers/folder.rs
@@ -124,3 +124,195 @@ pub async fn read_file(
         Err(e) => Err(ApiError::not_found(format!("Failed to read file: {}", e))),
     }
 }
+
+// ─── List Folder Handler (web-based picker) ─────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct ListFolderQuery {
+    pub path: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FolderEntry {
+    pub name: String,
+    pub is_git_repo: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListFolderResponse {
+    /// Absolute path that was listed (as supplied by the client; not canonicalized).
+    pub path: String,
+    /// Parent dir of `path`, or null if at filesystem root.
+    pub parent: Option<String>,
+    /// Sub-directories under `path`. Files and dotfiles excluded.
+    /// Sorted case-insensitively by name.
+    pub entries: Vec<FolderEntry>,
+    /// User's home dir, for "Home" button convenience.
+    pub home: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum ListFolderError {
+    BadRequest(String),
+    NotFound(String),
+    Internal(String),
+}
+
+impl std::fmt::Display for ListFolderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BadRequest(m) | Self::NotFound(m) | Self::Internal(m) => f.write_str(m),
+        }
+    }
+}
+
+/// Pure function for unit-testing. The axum handler wraps this with Result→HTTP.
+pub fn list_folder_inner(q: ListFolderQuery) -> Result<ListFolderResponse, ListFolderError> {
+    let raw = q.path.trim();
+    if !raw.starts_with('/') {
+        return Err(ListFolderError::BadRequest("path must be absolute".into()));
+    }
+    // Textual `..` check only — this does NOT defend against symlink-based
+    // traversal. The deployment trust model assumes the auth layer (HMAC for
+    // `grove mobile`, Cloudflare Access / equivalent for public deploys) gates
+    // who can call this endpoint. If you ever expose this without an auth
+    // layer in front, add `canonicalize()` + an allowlist-prefix check.
+    if raw.split('/').any(|seg| seg == "..") {
+        return Err(ListFolderError::BadRequest(
+            "path must not contain `..`".into(),
+        ));
+    }
+    let p = std::path::Path::new(raw);
+    let meta = match std::fs::metadata(p) {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(ListFolderError::NotFound("path not found".into()))
+        }
+        Err(e) => return Err(ListFolderError::Internal(format!("stat failed: {}", e))),
+    };
+    if !meta.is_dir() {
+        return Err(ListFolderError::BadRequest(
+            "path is not a directory".into(),
+        ));
+    }
+    let read = std::fs::read_dir(p)
+        .map_err(|e| ListFolderError::Internal(format!("read_dir failed: {}", e)))?;
+    let mut entries: Vec<FolderEntry> = read
+        .filter_map(|r| r.ok())
+        .filter_map(|de| {
+            let name = de.file_name().to_string_lossy().to_string();
+            if name.starts_with('.') {
+                return None;
+            }
+            let ft = de.file_type().ok()?;
+            if !ft.is_dir() {
+                return None;
+            }
+            // try_exists distinguishes "doesn't exist" from "couldn't stat" — the
+            // latter (permission denied, etc.) shouldn't false-flag as a git repo.
+            let is_git_repo = de.path().join(".git").try_exists().unwrap_or(false);
+            Some(FolderEntry { name, is_git_repo })
+        })
+        .collect();
+    entries.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    Ok(ListFolderResponse {
+        path: raw.to_string(),
+        parent: p.parent().map(|pp| pp.to_string_lossy().to_string()),
+        entries,
+        home: std::env::var("HOME").ok(),
+    })
+}
+
+pub async fn list_folder(
+    Query(q): Query<ListFolderQuery>,
+) -> Result<Json<ListFolderResponse>, (StatusCode, Json<ApiError>)> {
+    match list_folder_inner(q) {
+        Ok(r) => Ok(Json(r)),
+        Err(ListFolderError::BadRequest(msg)) => Err(ApiError::bad_request(&msg)),
+        Err(ListFolderError::NotFound(msg)) => Err(ApiError::not_found(&msg)),
+        Err(ListFolderError::Internal(msg)) => Err(ApiError::internal(&msg)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn setup_tree(td: &TempDir) {
+        let root = td.path();
+        fs::create_dir(root.join("repo-a")).unwrap();
+        fs::create_dir(root.join("repo-a/.git")).unwrap();
+        fs::create_dir(root.join("plain-dir")).unwrap();
+        fs::write(root.join("note.md"), "x").unwrap();
+        fs::write(root.join(".hidden"), "x").unwrap();
+    }
+
+    #[test]
+    fn list_folder_returns_entries_with_git_flag() {
+        let td = TempDir::new().unwrap();
+        setup_tree(&td);
+        let q = ListFolderQuery {
+            path: td.path().to_string_lossy().into(),
+        };
+        let resp = list_folder_inner(q).expect("ok");
+        let names: Vec<_> = resp.entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"repo-a"));
+        assert!(names.contains(&"plain-dir"));
+        assert!(
+            !names.contains(&"note.md"),
+            "files should not appear (dirs only)"
+        );
+        assert!(!names.contains(&".hidden"), "dotfiles hidden by default");
+        let repo_a = resp.entries.iter().find(|e| e.name == "repo-a").unwrap();
+        assert!(repo_a.is_git_repo);
+        let plain = resp.entries.iter().find(|e| e.name == "plain-dir").unwrap();
+        assert!(!plain.is_git_repo);
+        assert_eq!(resp.path, td.path().to_string_lossy());
+        assert_eq!(
+            resp.parent.as_deref(),
+            td.path().parent().map(|p| p.to_str().unwrap())
+        );
+    }
+
+    #[test]
+    fn list_folder_rejects_relative_path() {
+        let q = ListFolderQuery {
+            path: "relative/path".into(),
+        };
+        let err = list_folder_inner(q).unwrap_err();
+        assert!(err.to_string().contains("absolute"));
+    }
+
+    #[test]
+    fn list_folder_rejects_traversal() {
+        let q = ListFolderQuery {
+            path: "/etc/../etc".into(),
+        };
+        let err = list_folder_inner(q).unwrap_err();
+        assert!(err.to_string().contains(".."));
+    }
+
+    #[test]
+    fn list_folder_404_on_missing() {
+        let q = ListFolderQuery {
+            path: "/no/such/path/xyz123".into(),
+        };
+        let err = list_folder_inner(q).unwrap_err();
+        let s = err.to_string();
+        assert!(s.contains("not found") || s.contains("No such"));
+    }
+
+    #[test]
+    fn list_folder_rejects_file_path() {
+        let td = TempDir::new().unwrap();
+        let file = td.path().join("a.txt");
+        fs::write(&file, "x").unwrap();
+        let q = ListFolderQuery {
+            path: file.to_string_lossy().into(),
+        };
+        let err = list_folder_inner(q).unwrap_err();
+        assert!(err.to_string().contains("not a directory"));
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -179,6 +179,7 @@ pub fn create_api_router() -> Router {
         )
         // Folder selection API
         .route("/browse-folder", get(handlers::folder::browse_folder))
+        .route("/folders/list", get(handlers::folder::list_folder))
         // Read file API (for Plan File rendering)
         .route("/read-file", get(handlers::folder::read_file))
         // Terminal WebSocket


### PR DESCRIPTION
## Problem

`grove web` and `grove mobile` are advertised as remote-accessible (see `docs/install.md` "Grove ships as a single binary with the Web IDE embedded"), but the **Add Project → Browse** button shells out to a native OS dialog via `src/api/handlers/folder.rs::browse_folder`:

- Linux: `zenity --file-selection --directory` (or `kdialog`)
- macOS: `osascript` AppleScript `choose folder`
- Windows: PowerShell `FolderBrowserDialog`

The dialog opens on the **Grove server's display** — which doesn't exist on a headless host (e.g. self-hosted on a homelab VM behind a Cloudflare Tunnel). Remote users click Browse and nothing happens; they have to fall back to typing the absolute path or SSHing in to use `grove register <path>`.

This was discovered during a real Grove pilot on a headless Linux server (no \$DISPLAY) accessed via a Cloudflare Tunnel from a remote browser.

## Solution

Add a web-based folder picker as a **fallback** to the existing native dialog. The native dialog remains the default — users on macOS / Linux desktop / Windows still get the OS-native UX. When the native handler returns `{path: null}` (the signal that no display was available) OR throws, the frontend opens a new `FolderTreePickerDialog` that walks the server's filesystem via a new `/api/v1/folders/list` endpoint.

## Changes

### Backend (`src/api/handlers/folder.rs`, `src/api/mod.rs`)
- New `list_folder` axum handler + pure `list_folder_inner` for unit testing
- New types: `ListFolderQuery`, `FolderEntry { name, path, is_git_repo }`, `ListFolderResponse { path, parent, entries, home }`
- Typed `ListFolderError` enum → HTTP 400 (bad path) / 403 (permission) / 404 (not found) / 500 (internal)
- Per-entry absolute `path` returned so the frontend doesn't assemble paths client-side (handles trailing-slash edge cases + Windows path separators correctly)
- Path-safety: absolute-only, textual `..` rejection. Symlink traversal is NOT defended against — the deployment trust model assumes the auth layer (HMAC for `grove mobile`, equivalent for public deploys) gates who can call this endpoint. Source comment documents the limitation and the remediation if that assumption ever breaks.
- HOME falls back to USERPROFILE on Windows
- Route registered: `GET /api/v1/folders/list?path=<absolute>`
- 5 unit tests cover happy path (entries + `is_git_repo` flag + `path` + case-insensitive sort + file/dotfile exclusion), relative-path rejection, `..` rejection, 404, file-path 400

### Frontend (`grove-web/src/api/projects.ts`, `grove-web/src/components/Projects/`)
- New `listFolder` client method + `FolderEntry` / `ListFolderResponse` types mirroring the Rust shapes
- New `FolderTreePickerDialog` component — breadcrumb-style server-side dir browser with Up / Home / click-into-dir navigation, per-entry `git` badge, theme-var styled, race-guarded with `reqIdRef`, error display via `extractErrorMessage` helper (apiClient throws plain object literals, not Error instances), unmount-safe
- `AddProjectDialog` Browse buttons (existing + parent-dir tabs) fall back to the new picker when the native dialog returns `{path: null}` or throws

## Security

The new endpoint exposes the Grove host's filesystem **structure** (directory names) to anyone with an authenticated Grove session. Same trust boundary as existing endpoints — the auth layer gates remote access. No file contents leak; only directory names + per-entry `is_git_repo` boolean. Dotfiles excluded by default. Symlinks are followed (intentional — `is_git_repo` checks for `.git/` via `try_exists()`).

If you deploy Grove publicly without an auth layer in front, the source comment in `folder.rs` calls out exactly what to add: `canonicalize()` + an allowlist-prefix check. We considered adding that to this patch but it would force a config schema (where's the allowlist defined?) — left as a follow-up if/when there's a clear policy.

## Testing

- 5 new backend unit tests (`cargo test --bin grove api::handlers::folder::tests`) — all passing
- `cargo clippy --bin grove` — no new warnings introduced (pre-existing warnings in `src/api/auth.rs:284` and `src/api/handlers/extension.rs:837` are unchanged and out of scope)
- `pnpm tsc --noEmit` + `pnpm lint --max-warnings 0` — clean
- Manual smoke test on a headless Linux host: HTTP 200 on valid path, 400 on relative / file-path, 404 on missing. Frontend Browse button correctly falls back to the new dialog when the native handler returns `{path: null}`. Breadcrumb navigation, Up/Home buttons, git-repo badges all work. Path containing spaces / special chars handled correctly via URLSearchParams encoding.
- Frontend has no test framework in the repo — verification was tsc + lint + manual smoke

## Review notes

This patch was reviewed independently by two LLM-based code reviewers (one Claude-based, one GPT-based). Both initial reviews flagged real issues that have been addressed in the "address combined review feedback" commit:

- **From the Claude reviewer**: missing `setError("")` clears on browse success paths; `setPickerOpen(null)` missing from dialog reset block; commit history needed squashing (done — 5 commits final)
- **From the Codex reviewer**: initial probe in dialog was not race-guarded (unmount→remount could fire `setError` on stale instance); Select button was enabled with stale data when an error was displayed; `FolderEntry` lacked `path` field so client-side joining had edge cases at `/` and on Windows; `PermissionDenied` should map to 403 not 500; HOME → USERPROFILE fallback for Windows

Disagreement-of-opinion preserved (not blocking): the Codex reviewer flagged the textual `..` check as a Critical security issue. The Claude reviewer accepted the trust-model comment as appropriate for the documented deployment model. We've kept the trust-model approach — see Security section above.

## Known limitations / follow-ups (not blockers)

- `browse_folder` hangs when `\$DISPLAY` is set but X is dead (pre-existing upstream behavior — not introduced by this PR). The fallback only triggers on `{path: null}` or thrown error, so this DISPLAY-set-but-X-dead edge case requires the user to either wait or kill the request. A future patch could add a frontend timeout on the native call.
- Transition UX flicker in the picker (previous entries stay visible during folder-click load, then swap once response arrives)
- Cmd+Enter to confirm "Select this folder" (consistency with `AddProjectDialog`)
- Probe-then-load round-trip on first open (two API calls when one would do)
- Property-based tests on the path-safety check

## Out of scope

- File picker for non-folder selection (`read_file` is unchanged)
- Symlink-target display
- File-size / mtime columns
- Authentication / allowlist (deferred — needs config schema discussion)

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>