### PR TITLE
Fix iOS standalone-PWA layout: safe-area, input zoom, full-screen fill

### DIFF
--- a/grove-web/src/App.tsx
+++ b/grove-web/src/App.tsx
@@ -225,19 +225,48 @@ function AppContent() {
     const vv = window.visualViewport;
     const root = document.documentElement;
     const recompute = () => {
+      // The keyboard can only be up if a text field is focused. In a
+      // standalone PWA (viewport-fit=cover) `innerHeight - vv.height` is a
+      // non-zero *static* difference even with the keyboard closed — counting
+      // that as a keyboard inset leaves bottom-anchored UI (the chat composer)
+      // floating well above the bottom, with a large empty gap. Gate on focus
+      // so a closed keyboard always yields 0.
+      const ae = document.activeElement as HTMLElement | null;
+      const editing =
+        !!ae && (ae.tagName === "INPUT" || ae.tagName === "TEXTAREA" || ae.isContentEditable);
       const offset = window.innerHeight - vv.height - vv.offsetTop;
-      root.style.setProperty("--grove-kb-inset", `${offset > 50 ? offset : 0}px`);
+      root.style.setProperty("--grove-kb-inset", `${editing && offset > 50 ? offset : 0}px`);
     };
     vv.addEventListener("resize", recompute);
     vv.addEventListener("scroll", recompute);
     window.addEventListener("resize", recompute);
+    // Recompute on focus changes so the inset drops to 0 the moment the
+    // composer blurs (keyboard dismissed), even if no viewport event fires.
+    window.addEventListener("focusin", recompute);
+    window.addEventListener("focusout", recompute);
     recompute();
     return () => {
       vv.removeEventListener("resize", recompute);
       vv.removeEventListener("scroll", recompute);
       window.removeEventListener("resize", recompute);
+      window.removeEventListener("focusin", recompute);
+      window.removeEventListener("focusout", recompute);
       root.style.removeProperty("--grove-kb-inset");
     };
+  }, []);
+
+  // Tag the document when running as an installed/standalone PWA so the app
+  // shell can use `100vh` instead of `100dvh`. On iOS standalone (viewport-fit
+  // =cover) `100dvh` resolves to the screen height MINUS the top safe-area
+  // inset, leaving an unfilled strip at the physical bottom; `100vh` is the
+  // true full screen there. Browser tabs keep `100dvh` (where `100vh` would
+  // overshoot behind the URL bar). Covers both the standard media query and
+  // iOS's legacy `navigator.standalone`.
+  useEffect(() => {
+    const standalone =
+      window.matchMedia?.("(display-mode: standalone)").matches ||
+      (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
+    document.documentElement.classList.toggle("grove-standalone", !!standalone);
   }, []);
 
   useEffect(() => {
@@ -1194,7 +1223,7 @@ function AppContent() {
   // Mobile layout
   if (isMobile) {
     return (
-      <div className="flex flex-col h-[100dvh] bg-[var(--color-bg)] overflow-hidden pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
+      <div className="grove-app-shell flex flex-col bg-[var(--color-bg)] overflow-hidden pt-[env(safe-area-inset-top)]">
         <UpdateBanner />
         <MobileHeader
           onMenuOpen={() => setDrawerOpen(true)}
@@ -1213,7 +1242,7 @@ function AppContent() {
           />
         </MobileDrawer>
 
-        <main className={`relative flex-1 ${(activeItem === "tasks" && tasksMode !== "blitz") || activeItem === "work" ? "overflow-hidden" : "overflow-y-auto"}`}>
+        <main className={`relative min-h-0 flex-1 ${(activeItem === "tasks" && tasksMode !== "blitz") || activeItem === "work" ? "overflow-hidden" : "overflow-y-auto"}`}>
           {/* TasksPage always mounted on mobile too */}
           <div
             className="h-full p-3"

--- a/grove-web/src/App.tsx
+++ b/grove-web/src/App.tsx
@@ -1194,7 +1194,7 @@ function AppContent() {
   // Mobile layout
   if (isMobile) {
     return (
-      <div className="flex flex-col h-[100dvh] bg-[var(--color-bg)] overflow-hidden">
+      <div className="flex flex-col h-[100dvh] bg-[var(--color-bg)] overflow-hidden pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
         <UpdateBanner />
         <MobileHeader
           onMenuOpen={() => setDrawerOpen(true)}

--- a/grove-web/src/components/Layout/MobileDrawer.tsx
+++ b/grove-web/src/components/Layout/MobileDrawer.tsx
@@ -53,7 +53,7 @@ export function MobileDrawer({ isOpen, onClose, children }: MobileDrawerProps) {
             animate={{ x: 0 }}
             exit={{ x: "-100%" }}
             transition={{ type: "spring", damping: 30, stiffness: 300 }}
-            className="fixed inset-y-0 left-0 z-50 w-72 bg-[var(--color-bg)] border-r border-[var(--color-border)] flex flex-col"
+            className="fixed inset-y-0 left-0 z-50 w-72 bg-[var(--color-bg)] border-r border-[var(--color-border)] flex flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)]"
           >
             {/* Close button */}
             <div className={`flex items-center justify-end px-4 ${shouldAvoidTrafficLights ? "h-[56px] pt-[14px]" : "h-12"}`}>

--- a/grove-web/src/components/Tasks/TaskView/TaskChat.tsx
+++ b/grove-web/src/components/Tasks/TaskView/TaskChat.tsx
@@ -7099,7 +7099,7 @@ export function TaskChat({
           )}
 
           {/* Input */}
-          <div ref={inputAreaRef} className="pointer-events-none absolute inset-x-0 z-10 px-3 pb-4 pt-2" style={{ bottom: "var(--grove-kb-inset, 0px)" }}>
+          <div ref={inputAreaRef} className="pointer-events-none absolute inset-x-0 z-10 px-3 pb-4 pt-2" style={{ bottom: "max(var(--grove-kb-inset, 0px), env(safe-area-inset-bottom))" }}>
             <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-[linear-gradient(to_top,color-mix(in_srgb,var(--color-bg)_96%,transparent),transparent)]" />
             <div className="chatbox-cq-root pointer-events-auto relative mx-auto w-full max-w-[920px]">
               {isRemoteSession && (

--- a/grove-web/src/index.css
+++ b/grove-web/src/index.css
@@ -47,6 +47,38 @@ textarea,
   -webkit-user-select: text;
 }
 
+/* App shell height. In a normal browser tab `100dvh` is correct (it shrinks
+   with the URL bar, unlike `100vh`). But in an installed/standalone iOS PWA
+   with viewport-fit=cover, `100dvh` resolves to the screen height MINUS the
+   top safe-area inset, so the app fails to reach the physical bottom and a
+   blank strip shows there. `100vh` is the true full screen in standalone.
+   CRITICAL: html/body/#root are `height:100%; overflow:hidden` — in standalone
+   that `100%` is the same short viewport, so it clips the shell no matter what
+   height the shell itself uses. The full-screen height must be applied up the
+   whole chain; the shell then just fills its (now full-height) parent. The
+   shell's own top safe-area padding insets the content correctly. */
+.grove-app-shell {
+  height: 100dvh;
+}
+@media (display-mode: standalone) {
+  html,
+  body,
+  #root {
+    height: 100vh;
+  }
+  .grove-app-shell {
+    height: 100%;
+  }
+}
+html.grove-standalone,
+html.grove-standalone body,
+html.grove-standalone #root {
+  height: 100vh;
+}
+html.grove-standalone .grove-app-shell {
+  height: 100%;
+}
+
 /* Prevent iOS Safari from auto-zooming when focusing an input/textarea
    with font-size < 16px. `max(16px, 1em)` lets larger inputs keep their
    intentional size without squashing them down to 16px, while still
@@ -56,7 +88,10 @@ textarea,
 @media (max-width: 768px) {
   input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not(.compact),
   textarea:not(.compact),
-  select:not(.compact) {
+  select:not(.compact),
+  /* The chat composer is a contentEditable div, not a textarea — it must also
+     meet the 16px threshold or iOS auto-zooms (and the zoom sticks) on focus. */
+  [contenteditable="true"]:not(.compact) {
     font-size: max(16px, 1em);
   }
 }


### PR DESCRIPTION
## What
Fixes layout problems specific to the installed (home-screen) PWA on iOS, where `apple-mobile-web-app-status-bar-style=black-translucent` + `viewport-fit=cover` draw content under the status bar / Dynamic Island and home indicator.

## Fixes
- **Safe-area insets**: the mobile shell + drawer now pad `env(safe-area-inset-*)`, so the hamburger clears the status bar and the drawer's controls clear the indicator.
- **No input focus-zoom**: the chat composer is a `contentEditable` div (not a `<textarea>`), so it fell below the iOS 16px auto-zoom threshold — the mobile 16px rule now covers `[contenteditable]`, and the viewport is scale-locked so a stray zoom can't stick.
- **Full-screen fill**: in standalone, `100dvh` resolves to *screen minus the top inset*, and `html/body/#root { height:100% }` (also the short viewport) clipped the shell, leaving a blank strip at the bottom. The full-screen height is now applied up the whole `html/body/#root` chain in standalone (`display-mode: standalone` + a `navigator.standalone` class); the shell fills `100%` of it. The composer floats `max(keyboard-inset, safe-area-inset-bottom)` so it rides the keyboard and otherwise clears the home indicator.
- Keyboard inset is gated on actual input focus, so a closed keyboard yields 0 (no floating composer).

Browser tabs keep `100dvh` (where `100vh` overshoots behind the URL bar); only the standalone PWA switches to `100vh`.

## Testing
- frontend `pnpm build` + eslint clean
- verified on-device (iOS standalone PWA): hamburger tappable, no zoom, fills to the bottom edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)