### PR TITLE
feat(chat): name new sessions after their agent instead of a timestamp

### DIFF
--- a/grove-web/src/components/Tasks/TaskView/TaskChat.tsx
+++ b/grove-web/src/components/Tasks/TaskView/TaskChat.tsx
@@ -1081,12 +1081,6 @@ function pruneChatViewMessages(
   };
 }
 
-function buildDefaultSessionTitle() {
-  const now = new Date();
-  const pad = (value: number) => value.toString().padStart(2, "0");
-  return `New Session ${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}`;
-}
-
 function OverflowTitle({
   text,
   className = "",
@@ -4731,10 +4725,13 @@ export function TaskChat({
     async (agent: string) => {
       setShowAgentPicker(false);
       try {
+        // Omit the title so the backend names the session after the chosen
+        // agent ("Claude Code", "Gemini", a persona name, …) — far easier to
+        // tell sessions apart in the Blitz grid than "New Session <date>".
         const newChat = await createChat(
           projectId,
           task.id,
-          buildDefaultSessionTitle(),
+          undefined,
           agent,
         );
         setChats((prev) => [...prev, newChat]);

--- a/grove-web/src/components/Tasks/TaskView/useInitialChatLoad.ts
+++ b/grove-web/src/components/Tasks/TaskView/useInitialChatLoad.ts
@@ -6,12 +6,6 @@ import {
   writeLastActiveTab,
 } from "../../../utils/lastActiveTab";
 
-function buildDefaultSessionTitle(): string {
-  const now = new Date();
-  const pad = (value: number) => value.toString().padStart(2, "0");
-  return `New Session ${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}`;
-}
-
 interface Params {
   projectId: string;
   taskId: string;
@@ -49,11 +43,9 @@ export function useInitialChatLoad({
       }
       if (chatList.length === 0) {
         try {
-          const newChat = await createChat(
-            projectId,
-            taskId,
-            buildDefaultSessionTitle(),
-          );
+          // Omit the title so the backend derives it from the agent
+          // ("Claude Code", "Gemini", …) instead of a "New Session <date>".
+          const newChat = await createChat(projectId, taskId);
           chatList = [newChat];
         } catch (err) {
           console.error("Failed to create initial chat:", err);

--- a/src/api/handlers/acp.rs
+++ b/src/api/handlers/acp.rs
@@ -1111,6 +1111,61 @@ pub async fn list_chats(
 }
 
 /// Create a new chat for a task
+/// Resolve an agent id to a human-friendly display name, for use as a default
+/// chat title. Personas (`ca-…`) → their configured name; custom ACP servers →
+/// their name; built-in agents → the supplement display name ("Claude Code",
+/// "Gemini", …); anything else falls back to the raw id.
+pub(crate) fn agent_display_name(agent: &str, cfg: &config::Config) -> String {
+    // Persona (SQLite) — try_get_persona only touches the DB for `ca-` ids.
+    if let Ok(Some(persona)) = crate::storage::custom_agent::try_get_persona(agent) {
+        return persona.name;
+    }
+    // Custom ACP server (config TOML).
+    if let Some(server) = cfg.acp.custom_agents.iter().find(|s| s.id == agent) {
+        return server.name.clone();
+    }
+    // Built-in agent — registry display name. Canonicalize first so legacy
+    // ids on chats written before the v2.6 remap migration still resolve.
+    let canonical = crate::storage::installed_agents::canonicalize_agent_id(agent);
+    if let Some(name) = crate::storage::agent_registry::get()
+        .agents
+        .iter()
+        .find(|a| a.id == canonical)
+        .map(|a| a.name.clone())
+    {
+        return name;
+    }
+    agent.to_string()
+}
+
+/// Build a default chat title from the agent's display name, disambiguated
+/// against the task's existing chats with a numeric suffix ("Claude Code",
+/// "Claude Code 2", …). This replaces the old "New Session <date>" titles so a
+/// task with several sessions is legible at a glance (e.g. in the Blitz grid /
+/// chat picker) without opening each one.
+pub(crate) fn default_chat_title(
+    agent: &str,
+    cfg: &config::Config,
+    project: &str,
+    task_id: &str,
+) -> String {
+    let base = agent_display_name(agent, cfg);
+    let existing: std::collections::HashSet<String> = tasks::load_chat_sessions(project, task_id)
+        .map(|chats| chats.into_iter().map(|c| c.title).collect())
+        .unwrap_or_default();
+    if !existing.contains(&base) {
+        return base;
+    }
+    let mut n = 2;
+    loop {
+        let candidate = format!("{base} {n}");
+        if !existing.contains(&candidate) {
+            return candidate;
+        }
+        n += 1;
+    }
+}
+
 pub async fn create_chat(
     Path((project_id, task_id)): Path<(String, String)>,
     Json(body): Json<CreateChatRequest>,
@@ -1172,7 +1227,8 @@ pub async fn create_chat(
     let now = chrono::Utc::now();
     let title = body
         .title
-        .unwrap_or_else(|| format!("New Chat {}", now.format("%Y-%m-%d %H:%M")));
+        .filter(|t| !t.trim().is_empty())
+        .unwrap_or_else(|| default_chat_title(&agent, &cfg, &project_key, &task_id));
 
     let chat = tasks::ChatSession {
         id: tasks::generate_chat_id(),

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -2785,11 +2785,13 @@ async fn start_chat_impl(p: StartChatParams) -> Result<CallToolResult, McpError>
     let resolved = acp::resolve_agent(&agent_name)
         .ok_or_else(|| McpError::invalid_params(format!("Unknown agent: {}", agent_name), None))?;
 
-    // Create chat session in storage
+    // Create chat session in storage. Default the title to the agent's display
+    // name (disambiguated with a numeric suffix) so spawned sessions are
+    // legible at a glance, matching the web create-chat path.
     let now = chrono::Utc::now();
-    let title = p
-        .name
-        .unwrap_or_else(|| format!("New Chat {}", now.format("%Y-%m-%d %H:%M")));
+    let title = p.name.filter(|t| !t.trim().is_empty()).unwrap_or_else(|| {
+        crate::api::handlers::acp::default_chat_title(&agent_name, &cfg, &project_key, &p.task_id)
+    });
     let chat_id = tasks::generate_chat_id();
 
     let chat = tasks::ChatSession {


### PR DESCRIPTION
## Problem

New chat sessions are titled `New Session <date>` (e.g. `New Session 2026-06-02 14:30`). When a task has several sessions — especially in the Blitz grid or the chat picker — they're impossible to tell apart without opening each one, since the only distinguishing part is a timestamp.

## Change

Derive the default chat title from the **agent running the session**:

- **Personas** → their configured name (e.g. `QA Reviewer`)
- **Custom ACP servers** → their name
- **Built-in agents** → the supplement display name (`Claude Code`, `Gemini`, `CodeX`, …)
- disambiguated within a task with a numeric suffix: `Claude Code`, `Claude Code 2`, …

The logic lives backend-side in `create_chat` (`agent_display_name` + `default_chat_title`), so **every creation path** benefits — the web new-chat picker, the initial auto-created chat, and MCP/orchestrator spawns via `start_chat`. The frontend simply stops sending the timestamp title and lets the backend name it.

A user-supplied (non-empty) title still wins, and existing sessions keep their titles — this only affects newly created ones.

## Verification

Created chats against a running instance:

| agent | resulting title |
|---|---|
| `claude` | `Claude Code` |
| `claude` (2nd) | `Claude Code 2` |
| `gemini` | `Gemini` |

- `cargo check` clean
- `tsc -b && vite build` clean
- `eslint --max-warnings 0` clean on touched files

## Files

- `src/api/handlers/acp.rs` — `agent_display_name()` + `default_chat_title()`; `create_chat` uses them when no title is supplied
- `src/cli/mcp.rs` — `start_chat` shares the same default
- `grove-web/.../TaskChat.tsx`, `useInitialChatLoad.ts` — stop sending the timestamp title; remove the now-dead `buildDefaultSessionTitle` helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)