### PR TITLE
feat(blitz): grid workspace on flexlayout-react (supersedes #18)

### DIFF
--- a/grove-web/src/components/Blitz/BlitzFlexWorkspace.tsx
+++ b/grove-web/src/components/Blitz/BlitzFlexWorkspace.tsx
@@ -1,0 +1,404 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { Layout, Model, Actions, DockLocation, TabNode, Node as FlexNode } from "flexlayout-react";
+import { Plus, AlignHorizontalSpaceAround } from "lucide-react";
+import "flexlayout-react/style/light.css";
+import "../Tasks/PanelSystem/flexlayout-theme.css";
+import { TaskChat } from "../Tasks/TaskView/TaskChat";
+import { ChatPickerDropdown } from "./ChatPickerDropdown";
+import { SessionPickerPane } from "./SessionPickerPane";
+import type { BlitzTask } from "../../data/types";
+import type { SlotAssignment } from "./useBlitzGrid";
+import {
+  type BlitzTabConfig,
+  type OpenTab,
+  BLITZ_TAB_COMPONENT,
+  GROVE_TASK_MIME,
+  buildColumnsModelJson,
+  createInitialModel,
+  persistModelJson,
+  tabNodeFor,
+} from "./blitzFlexModel";
+
+/** Column presets: label → number of columns to tile open chats into evenly.
+ *  (2 columns with four chats = a 2×2; 3 columns with six = a 3×2.) */
+const GRID_PRESETS: ReadonlyArray<{ label: string; cols: number; title: string }> = [
+  { label: "1", cols: 1, title: "Single column" },
+  { label: "2", cols: 2, title: "Two columns (2×2 with four chats)" },
+  { label: "3", cols: 3, title: "Three columns (3×2 with six chats)" },
+];
+
+interface BlitzFlexWorkspaceProps {
+  blitzTasks: BlitzTask[];
+}
+
+/**
+ * One pinned chat rendered inside a FlexLayout tab. TaskChat stays MOUNTED
+ * even while disconnected so its reconnect machinery keeps running — the
+ * "reconnecting" state is a non-blocking overlay, not an unmount (same fix as
+ * the old GridSlot).
+ */
+function BlitzChatPane({
+  cfg,
+  blitzTasks,
+  onPickSession,
+  onCancel,
+}: {
+  cfg: BlitzTabConfig;
+  blitzTasks: BlitzTask[];
+  onPickSession: (chat: { id: string; name: string }) => void;
+  onCancel: () => void;
+}) {
+  const [stale, setStale] = useState(false);
+  const hasConnectedRef = useRef(false);
+  // Locally-picked session, so the pane swaps to the chat the instant the user
+  // picks — flexlayout's Tab is memoized and won't re-invoke the factory on a
+  // config-only change (updateNodeAttributes), so we can't wait for cfg.chatId
+  // to propagate. onPickSession still persists it to the node config.
+  const [pickedChat, setPickedChat] = useState<{ id: string; name: string } | null>(null);
+
+  const chatId = cfg.chatId ?? pickedChat?.id;
+  const chatName = cfg.chatName ?? pickedChat?.name;
+
+  const live = useMemo(
+    () => blitzTasks.find((bt) => bt.projectId === cfg.projectId && bt.task.id === cfg.taskId),
+    [blitzTasks, cfg.projectId, cfg.taskId],
+  );
+
+  // A task dropped from the left list awaits a session pick.
+  if (!chatId) {
+    if (!cfg.projectId || !cfg.taskId) {
+      // Transient frame between tab creation and onDrop filling in the task.
+      return (
+        <div className="flex h-full items-center justify-center text-sm text-[var(--color-text-muted)]">
+          Loading…
+        </div>
+      );
+    }
+    return (
+      <SessionPickerPane
+        projectId={cfg.projectId}
+        taskId={cfg.taskId}
+        taskName={cfg.taskName}
+        onPick={(chat) => {
+          setPickedChat(chat); // instant local swap
+          onPickSession(chat); // persist to node config
+        }}
+        onCancel={onCancel}
+      />
+    );
+  }
+
+  if (!live) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-[var(--color-text-muted)]">
+        Chat unavailable
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full w-full min-h-0 min-w-0 overflow-hidden">
+      {/* Context breadcrumb — which project · task · chat this panel is, since
+          the tab only shows the chat name and several panels coexist. */}
+      <div className="flex items-center gap-1 shrink-0 px-2.5 py-1 text-[11px] leading-none border-b border-[var(--color-border)] bg-[var(--color-bg-secondary)] overflow-hidden">
+        <span className="shrink-0 text-[var(--color-text-muted)]">{cfg.projectName}</span>
+        <span className="shrink-0 text-[var(--color-text-muted)]">·</span>
+        <span className="truncate min-w-0 text-[var(--color-text)]">{cfg.taskName}</span>
+        <span className="shrink-0 text-[var(--color-text-muted)]">·</span>
+        <span className="truncate min-w-0 text-[var(--color-highlight)]">{chatName}</span>
+      </div>
+      <div className="relative flex flex-1 min-h-0 min-w-0 overflow-hidden">
+        <TaskChat
+          projectId={live.projectId}
+          task={live.task}
+          pinnedChatId={chatId}
+          hideHeader={true}
+          onConnected={() => {
+            hasConnectedRef.current = true;
+            setStale(false);
+          }}
+          onDisconnected={() => {
+            // Only flag stale after a successful connect — the initial WS setup
+            // fires onDisconnected before onConnected.
+            if (hasConnectedRef.current) setStale(true);
+          }}
+        />
+        {stale && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-[var(--color-bg)]/80 text-sm text-[var(--color-text-muted)] pointer-events-none">
+            Connection lost — reconnecting automatically…
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function countTabs(m: Model): number {
+  let n = 0;
+  m.visitNodes((node) => {
+    if (node.getType() === "tab") n += 1;
+  });
+  return n;
+}
+
+/**
+ * Blitz grid rebuilt on flexlayout-react: each pinned chat is a tab/panel you
+ * can split, resize, rearrange, add, and close — replacing the fixed
+ * 1/2/2×2/3×2 presets. Layout (and which chats are pinned where) persists to
+ * localStorage; existing preset grids migrate in on first load.
+ */
+export function BlitzFlexWorkspace({ blitzTasks }: BlitzFlexWorkspaceProps) {
+  const [model, setModel] = useState(() => createInitialModel());
+  const [isEmpty, setIsEmpty] = useState(() => countTabs(model) === 0);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const collectTabs = useCallback((): OpenTab[] => {
+    const tabs: OpenTab[] = [];
+    model.visitNodes((node) => {
+      if (node.getType() === "tab") {
+        tabs.push({ id: node.getId(), config: (node as TabNode).getConfig() as BlitzTabConfig });
+      }
+    });
+    return tabs;
+  }, [model]);
+
+  // Reset every panel to equal size in place (no reshape, no remount → chats
+  // stay connected). adjustWeights on each multi-child row evens columns and,
+  // via nested rows, the stacked panels within them.
+  const equalize = useCallback(() => {
+    const rows: Array<{ id: string; count: number }> = [];
+    model.visitNodes((node) => {
+      if (node.getType() === "row") {
+        const count = node.getChildren().length;
+        if (count > 1) rows.push({ id: node.getId(), count });
+      }
+    });
+    rows.forEach(({ id, count }) =>
+      model.doAction(Actions.adjustWeights(id, new Array(count).fill(100))),
+    );
+  }, [model]);
+
+  // Snap open chats into an even grid of `cols` columns (the optional
+  // "auto grid"). Tab ids are preserved so panels reconcile instead of
+  // remounting — connections survive the re-tile.
+  const tileColumns = useCallback(
+    (cols: number) => {
+      const tabs = collectTabs();
+      if (tabs.length === 0) return;
+      const json = buildColumnsModelJson(tabs, cols);
+      setModel(Model.fromJson(json));
+      persistModelJson(json);
+      setIsEmpty(false);
+    },
+    [collectTabs],
+  );
+
+  // Fill a needs-session placeholder tab (dropped task) with the chosen chat.
+  const assignSession = useCallback(
+    (nodeId: string, chat: { id: string; name: string }) => {
+      const node = model.getNodeById(nodeId);
+      if (!(node instanceof TabNode)) return;
+      // If this chat is already pinned in another panel, select it and drop the
+      // placeholder rather than duplicating (mirrors the Add chat path).
+      const tabs: TabNode[] = [];
+      model.visitNodes((n) => {
+        if (n.getType() === "tab") tabs.push(n as TabNode);
+      });
+      const existing = tabs.find(
+        (t) => t.getId() !== nodeId && (t.getConfig() as BlitzTabConfig | undefined)?.chatId === chat.id,
+      );
+      if (existing) {
+        model.doAction(Actions.selectTab(existing.getId()));
+        model.doAction(Actions.deleteTab(nodeId));
+        return;
+      }
+      const cfg = (node.getConfig() as BlitzTabConfig | undefined) ?? ({} as BlitzTabConfig);
+      model.doAction(
+        Actions.updateNodeAttributes(nodeId, {
+          name: chat.name,
+          config: { ...cfg, chatId: chat.id, chatName: chat.name, needsSession: false },
+        }),
+      );
+    },
+    [model],
+  );
+
+  const factory = useCallback(
+    (node: TabNode) => (
+      <BlitzChatPane
+        cfg={node.getConfig() as BlitzTabConfig}
+        blitzTasks={blitzTasks}
+        onPickSession={(chat) => assignSession(node.getId(), chat)}
+        onCancel={() => model.doAction(Actions.deleteTab(node.getId()))}
+      />
+    ),
+    [blitzTasks, assignSession, model],
+  );
+
+  // Accept a task dragged from the left list: drop a placeholder tab where the
+  // user aims, then fill in the task (onDrop) so its SessionPickerPane renders.
+  // dataTransfer values can't be read during dragenter, only on drop — so the
+  // placeholder carries no task until onDrop.
+  const onExternalDrag = useCallback(
+    (e: React.DragEvent<HTMLElement>) => {
+      if (!Array.from(e.dataTransfer.types).includes(GROVE_TASK_MIME)) return undefined;
+      return {
+        json: {
+          type: "tab",
+          name: "New chat",
+          component: BLITZ_TAB_COMPONENT,
+          enableClose: true,
+          config: {
+            projectId: "",
+            projectName: "",
+            taskId: "",
+            taskName: "",
+            needsSession: true,
+          } as BlitzTabConfig,
+        },
+        onDrop: (node?: FlexNode, event?: React.DragEvent<HTMLElement>) => {
+          // Act on the dropped node's OWN model, not a captured one: flexlayout
+          // keeps a static external-drag state that isn't cleared on cancel, so
+          // a closed-over model could be stale after a re-tile (setModel).
+          if (!(node instanceof TabNode) || !event) return;
+          const targetModel = node.getModel();
+          try {
+            const data = JSON.parse(event.dataTransfer.getData(GROVE_TASK_MIME)) as {
+              projectId: string;
+              projectName: string;
+              taskId: string;
+              taskName: string;
+            };
+            targetModel.doAction(
+              Actions.updateNodeAttributes(node.getId(), {
+                name: data.taskName,
+                config: {
+                  projectId: data.projectId,
+                  projectName: data.projectName,
+                  taskId: data.taskId,
+                  taskName: data.taskName,
+                  needsSession: true,
+                } as BlitzTabConfig,
+              }),
+            );
+            setIsEmpty(false);
+          } catch (err) {
+            console.warn("[blitzFlex] invalid task drop", err);
+            targetModel.doAction(Actions.deleteTab(node.getId()));
+          }
+        },
+      };
+    },
+    [],
+  );
+
+  const handleModelChange = useCallback((m: Model) => {
+    persistModelJson(m.toJson());
+    setIsEmpty(countTabs(m) === 0);
+  }, []);
+
+  const addChat = useCallback(
+    (a: SlotAssignment) => {
+      setPickerOpen(false);
+      // Already pinned somewhere? Select that tab instead of adding a duplicate.
+      const tabs: TabNode[] = [];
+      model.visitNodes((node) => {
+        if (node.getType() === "tab") tabs.push(node as TabNode);
+      });
+      const existing = tabs.find(
+        (t) => (t.getConfig() as BlitzTabConfig | undefined)?.chatId === a.chatId,
+      );
+      if (existing) {
+        model.doAction(Actions.selectTab(existing.getId()));
+        return;
+      }
+      const cfg: BlitzTabConfig = {
+        projectId: a.projectId,
+        projectName: a.projectName,
+        taskId: a.taskId,
+        taskName: a.taskName,
+        chatId: a.chatId,
+        chatName: a.chatName,
+      };
+      const active = model.getActiveTabset();
+      const targetId = active?.getId() ?? model.getRoot().getId();
+      model.doAction(Actions.addNode(tabNodeFor(cfg), targetId, DockLocation.CENTER, -1));
+      // handleModelChange fires from the action → persists + clears empty state.
+    },
+    [model],
+  );
+
+  return (
+    <div className="flex flex-col h-full bg-[var(--color-bg)]">
+      <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-[var(--color-border)]">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={equalize}
+            disabled={isEmpty}
+            title="Reset all panel sizes to equal"
+            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded-lg border border-[var(--color-border)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-tertiary)] disabled:opacity-40 disabled:pointer-events-none transition-colors"
+          >
+            <AlignHorizontalSpaceAround className="w-3.5 h-3.5" />
+            Equalize
+          </button>
+          <div className="flex items-center rounded-lg border border-[var(--color-border)] overflow-hidden text-xs">
+            <span className="px-2 py-1.5 text-[var(--color-text-muted)] border-r border-[var(--color-border)]">
+              Columns
+            </span>
+            {GRID_PRESETS.map((p) => (
+              <button
+                key={p.label}
+                type="button"
+                onClick={() => tileColumns(p.cols)}
+                disabled={isEmpty}
+                title={p.title}
+                className="px-2.5 py-1.5 text-[var(--color-text-muted)] hover:text-[var(--color-highlight)] hover:bg-[var(--color-highlight)]/10 disabled:opacity-40 disabled:pointer-events-none transition-colors border-l border-[var(--color-border)] first:border-l-0"
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setPickerOpen((v) => !v)}
+            aria-haspopup="dialog"
+            aria-expanded={pickerOpen}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded-lg border border-[var(--color-highlight)]/30 bg-[var(--color-highlight)]/10 text-[var(--color-highlight)] hover:bg-[var(--color-highlight)]/20 transition-colors"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Add chat
+          </button>
+          {pickerOpen && (
+            <ChatPickerDropdown
+              blitzTasks={blitzTasks}
+              onSelect={addChat}
+              onClose={() => setPickerOpen(false)}
+            />
+          )}
+        </div>
+      </div>
+
+      <div className="relative flex-1 min-h-0">
+        <div className="absolute inset-0">
+          <Layout
+            model={model}
+            factory={factory}
+            onModelChange={handleModelChange}
+            onExternalDrag={onExternalDrag}
+          />
+        </div>
+        {isEmpty && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-1.5 pointer-events-none text-[var(--color-text-muted)]">
+            <span className="text-sm">No chats pinned yet</span>
+            <span className="text-xs text-[var(--color-text-faint,var(--color-text-muted))]">
+              Drag a task from the list onto the canvas, or use “Add chat”
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/grove-web/src/components/Blitz/BlitzPage.tsx
+++ b/grove-web/src/components/Blitz/BlitzPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Search, ArrowLeft, ChevronRight, Laptop, Radio, Plus, Folder } from "lucide-react";
+import { Search, ArrowLeft, ChevronRight, ChevronLeft, Laptop, Radio, Plus, Folder, LayoutGrid } from "lucide-react";
 import { TaskInfoPanel } from "../Tasks/TaskInfoPanel";
 import { TaskView, type TaskViewHandle } from "../Tasks/TaskView";
 import { CommitDialog, ConfirmDialog, DirtyBranchDialog, MergeDialog } from "../Dialogs";
@@ -22,6 +22,7 @@ import {
 import { useCommand, useDefineCommand, useKeyboardScope, useContextKey, useHelpKeyDisplay } from "../../keyboard";
 import { RadioConnectDialog } from "./RadioConnectDialog";
 import { useBlitzTasks } from "./useBlitzTasks";
+import { BlitzFlexWorkspace } from "./BlitzFlexWorkspace";
 import { BlitzTaskListItem } from "./BlitzTaskListItem";
 import type { BlitzTask } from "../../data/types";
 import { MAIN_GROUP_ID, LOCAL_GROUP_ID } from "../../data/types";
@@ -107,6 +108,11 @@ export function BlitzPage({
   // Blitz-specific state
   const [selectedBlitzTask, setSelectedBlitzTask] = useState<BlitzTask | null>(null);
   const [mobileShowDetail, setMobileShowDetail] = useState(false);
+  const [gridMode, setGridMode] = useState(false);
+  // Desktop-only: collapse the Blitz task-list sidebar to a slim rail so the
+  // grid quadrants get the full width. Mirrors Zen's sidebar minimize; like
+  // Zen it's in-memory (resets on reload), not persisted.
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   // ── Unified drag-and-drop state ──────────────────────────────────────────
   // Single ref tracks the drag source; render state tracks visual feedback
@@ -505,6 +511,11 @@ export function BlitzPage({
         if (safetyTimer) clearTimeout(safetyTimer);
         safetyTimer = setTimeout(clearChips, 3000);
       }
+
+      // Grid toggle (Cmd/Ctrl+G) and grid Escape are catalog commands now —
+      // `blitz.grid.toggle` / `blitz.grid.exit` registered below — so they're
+      // rebindable, show in ⌘/ help, and respect scopes (no double-fire with
+      // tasks.escape).
     };
 
     const handleKeyUp = (e: KeyboardEvent) => {
@@ -532,7 +543,7 @@ export function BlitzPage({
       // Clean up class on unmount
       document.body.classList.remove('blitz-command-pressed');
     };
-  }, [mainListTasks, handleSelectTask, getTaskNotification, dismissNotification]);
+  }, []);
 
   // ── Unified drag handlers ───────────────────────────────────────────────
 
@@ -758,6 +769,8 @@ export function BlitzPage({
   // same key TasksPage publishes; last-write wins, both reflect the same
   // semantic "user has a task highlighted somewhere".
   useContextKey("taskSelected", hasTask);
+  // Gates blitz.grid.exit (Escape) so it only fires while the grid is showing.
+  useContextKey("blitzGridActive", gridMode);
 
   const enabledTask = useCallback(() => hasTask, [hasTask]);
   const enabledOpenWorkspace = useCallback(
@@ -829,6 +842,17 @@ export function BlitzPage({
     [navHandlers, enabledTask],
   );
   useCommand("task.search", () => searchInputRef.current?.focus(), []);
+
+  // Grid workspace toggle + exit (replaces the old raw window keydown listener).
+  // Both skip while a text surface is focused so the keyboard doesn't toggle the
+  // grid mid-typing or steal Escape from a composer/picker (its own blur/close
+  // handling runs instead) — matching the old raw handler's input skip.
+  const notTypingEnabled = useCallback(() => {
+    const a = document.activeElement as HTMLElement | null;
+    return !(a && (a.tagName === "INPUT" || a.tagName === "TEXTAREA" || a.isContentEditable));
+  }, []);
+  useCommand("blitz.grid.toggle", () => setGridMode((v) => !v), { enabled: notTypingEnabled }, [notTypingEnabled]);
+  useCommand("blitz.grid.exit", () => setGridMode(false), { enabled: notTypingEnabled }, [notTypingEnabled]);
 
   // Task lifecycle commands (catalog: workspace scope) — Blitz doesn't show
   // archived tasks so task.unarchive isn't wired here; Zen owns it. Studio
@@ -932,8 +956,10 @@ export function BlitzPage({
     scope: "tasks",
     hidden: true,
     handler: handleCloseTask,
-    enabled: () => pageState.inWorkspace || hasTask,
-  }, [handleCloseTask, pageState.inWorkspace, hasTask]);
+    // In grid mode, blitz.grid.exit owns Escape — keep these mutually exclusive
+    // so they never both fire when a task is also selected.
+    enabled: () => !gridMode && (pageState.inWorkspace || hasTask),
+  }, [handleCloseTask, pageState.inWorkspace, hasTask, gridMode]);
 
   // --- Workspace tab switching (Cmd+1-9, Cmd+W).
   const inWorkspace = pageState.inWorkspace;
@@ -1124,32 +1150,73 @@ export function BlitzPage({
         className={
           isMobile
             ? `${mobileShowDetail ? "hidden" : "w-full h-full"} bg-[var(--color-bg)] flex flex-col flex-shrink-0`
-            : "blitz-area glass-panel fixed top-3 bottom-3 left-3 w-72 z-40 rounded-2xl flex flex-col"
+            : `blitz-area glass-panel fixed top-3 bottom-3 left-3 z-40 rounded-2xl flex flex-col transition-[width] duration-200 ease-in-out ${
+                sidebarCollapsed ? "w-[72px]" : "w-72"
+              }`
         }
       >
+        {/* Collapsed rail (desktop): mirrors Zen's collapsed sidebar — the
+           drag strip up top, then the same bottom-pinned expand toggle (just a
+           ChevronRight, styled identically to Zen's Collapse button). Full
+           content is hidden while collapsed. */}
+        {!isMobile && sidebarCollapsed && (
+          <>
+            <div className="pt-8" data-tauri-drag-region data-window-drag-strip />
+            <div className="mt-auto px-2 pb-3">
+              <motion.button
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+                onClick={() => setSidebarCollapsed(false)}
+                aria-label="Expand sidebar"
+                title="Expand sidebar"
+                className="w-full flex items-center justify-center gap-3 px-3 py-2.5 mt-1 rounded-xl text-sm font-medium text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-border)] transition-colors"
+              >
+                <ChevronRight className="w-4 h-4" />
+              </motion.button>
+            </div>
+          </>
+        )}
+        {(isMobile || !sidebarCollapsed) && (
+        <>
         {/* Logo + Mode Brand
            pt-8 clears macOS traffic lights when Tauri title bar is Overlay.
            data-tauri-drag-region gives double-click-maximize; data-window-drag-strip
            is what the App.tsx native mousedown listener uses to call startDragging()
            (the bare data-tauri-drag-region silently fails after the first drag when
            the webview is loaded from http://localhost). */}
-        <div className={`px-4 pb-4 flex items-center justify-between ${shouldAvoidTrafficLights ? "pt-8" : "pt-4"}`} data-tauri-drag-region data-window-drag-strip>
+        <div className={`px-4 pb-4 flex flex-col items-start gap-3 ${shouldAvoidTrafficLights ? "pt-8" : "pt-4"}`} data-tauri-drag-region data-window-drag-strip>
           <LogoBrand mode="blitz" onToggle={onSwitchToZen} />
-          <button
-            onClick={() => setShowRadioConnect(true)}
-            className={`relative flex items-center gap-1.5 px-2.5 py-1.5 text-xs border rounded-lg transition-colors ${
-              radioConnected
-                ? "text-[var(--color-success)] border-[var(--color-success)]/30 bg-[var(--color-success)]/10 hover:bg-[var(--color-success)]/20"
-                : "text-[var(--color-text-muted)] hover:text-[var(--color-text)] bg-[var(--color-bg-secondary)] hover:bg-[var(--color-bg-tertiary)] border-[var(--color-border)]"
-            }`}
-            title={radioConnected ? `Radio Connected (${radioClients} device${radioClients > 1 ? "s" : ""})` : "Connect Radio (Walkie-Talkie)"}
-          >
-            <Radio className="w-3.5 h-3.5" />
-            Radio
-            {radioConnected && (
-              <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-success)] animate-pulse" />
-            )}
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setGridMode((v) => !v)}
+              aria-pressed={gridMode}
+              className={`relative flex items-center gap-1.5 px-2.5 py-1.5 text-xs border rounded-lg transition-colors whitespace-nowrap ${
+                gridMode
+                  ? "text-[var(--color-highlight)] border-[var(--color-highlight)]/30 bg-[var(--color-highlight)]/10 hover:bg-[var(--color-highlight)]/20"
+                  : "text-[var(--color-text-muted)] hover:text-[var(--color-text)] bg-[var(--color-bg-secondary)] hover:bg-[var(--color-bg-tertiary)] border-[var(--color-border)]"
+              }`}
+              title="Toggle grid workspace (⌘G)"
+            >
+              <LayoutGrid className="w-3.5 h-3.5" />
+              Grid view
+            </button>
+            <button
+              onClick={() => setShowRadioConnect(true)}
+              className={`relative flex items-center gap-1.5 px-2.5 py-1.5 text-xs border rounded-lg transition-colors ${
+                radioConnected
+                  ? "text-[var(--color-success)] border-[var(--color-success)]/30 bg-[var(--color-success)]/10 hover:bg-[var(--color-success)]/20"
+                  : "text-[var(--color-text-muted)] hover:text-[var(--color-text)] bg-[var(--color-bg-secondary)] hover:bg-[var(--color-bg-tertiary)] border-[var(--color-border)]"
+              }`}
+              title={radioConnected ? `Radio Connected (${radioClients} device${radioClients > 1 ? "s" : ""})` : "Connect Radio (Walkie-Talkie)"}
+            >
+              <Radio className="w-3.5 h-3.5" />
+              Radio
+              {radioConnected && (
+                <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-success)] animate-pulse" />
+              )}
+            </button>
+          </div>
         </div>
 
         {/* Search */}
@@ -1532,6 +1599,24 @@ export function BlitzPage({
             Press <kbd className="px-1 py-0.5 text-[10px] font-mono rounded border bg-[var(--color-bg-secondary)] border-[var(--color-border)]">{helpKey}</kbd> for shortcuts
           </button>
         </div>
+
+        {/* Collapse toggle — same affordance as the Zen sidebar (bottom-pinned
+           "‹ Collapse" button) so the two modes feel continuous. Desktop only. */}
+        {!isMobile && (
+          <div className="px-2 pb-3">
+            <motion.button
+              whileHover={{ scale: 1.02 }}
+              whileTap={{ scale: 0.98 }}
+              onClick={() => setSidebarCollapsed(true)}
+              className="w-full flex items-center justify-center gap-3 px-3 py-2.5 mt-1 rounded-xl text-sm font-medium text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-border)] transition-colors"
+            >
+              <ChevronLeft className="w-4 h-4" />
+              <span className="flex-1 text-left">Collapse</span>
+            </motion.button>
+          </div>
+        )}
+        </>
+        )}
       </aside>
 
       {/* Main Content
@@ -1547,7 +1632,9 @@ export function BlitzPage({
         className={
           isMobile
             ? `flex-1 overflow-hidden relative ${!mobileShowDetail ? "hidden" : ""}`
-            : "blitz-area flex-1 ml-[312px] mt-3 mr-3 mb-3 rounded-2xl bg-[var(--color-bg)] overflow-hidden relative"
+            : `blitz-area flex-1 mt-3 mr-3 mb-3 rounded-2xl bg-[var(--color-bg)] overflow-hidden relative transition-[margin] duration-200 ease-in-out ${
+                sidebarCollapsed ? "ml-[96px]" : "ml-[312px]"
+              }`
         }
         style={
           isMobile
@@ -1577,6 +1664,9 @@ export function BlitzPage({
            a task-centric panel (no "breathing-room dashboard" page like Zen
            has). */}
         <div className="h-full relative p-2">
+          {gridMode ? (
+            <BlitzFlexWorkspace blitzTasks={blitzTasks} />
+          ) : (
           <div className="h-full relative">
             {/* Task List Page */}
             <motion.div
@@ -1667,6 +1757,7 @@ export function BlitzPage({
               )}
             </AnimatePresence>
           </div>
+          )}
         </div>
       </main>
 

--- a/grove-web/src/components/Blitz/BlitzTaskListItem.tsx
+++ b/grove-web/src/components/Blitz/BlitzTaskListItem.tsx
@@ -2,6 +2,7 @@ import { Archive, ChevronUp, ChevronDown, Laptop, Zap, Code, GitBranch, Sparkles
 import type { BlitzTask } from "../../data/types";
 import { useIsMobile } from "../../hooks";
 import { Tooltip } from "../ui/Tooltip";
+import { GROVE_TASK_MIME } from "./blitzFlexModel";
 
 interface BlitzTaskListItemProps {
   blitzTask: BlitzTask;
@@ -81,6 +82,22 @@ export function BlitzTaskListItem({
       draggable={!isTouchDevice}
       onDragStart={isTouchDevice ? undefined : (e) => {
         e.dataTransfer.effectAllowed = 'move';
+        // Also advertise the task to the Blitz grid canvas (onExternalDrag) so
+        // it can be dropped in as a panel. Reorder-within-the-list still works
+        // off the parent's dragInfoRef, independent of this payload.
+        try {
+          e.dataTransfer.setData(
+            GROVE_TASK_MIME,
+            JSON.stringify({
+              projectId: blitzTask.projectId,
+              projectName: blitzTask.projectName,
+              taskId: task.id,
+              taskName: task.name,
+            }),
+          );
+        } catch {
+          /* setData can throw in odd DnD states — non-fatal */
+        }
         onDragStart?.();
       }}
       onDragOver={isTouchDevice ? undefined : (e) => {

--- a/grove-web/src/components/Blitz/ChatPickerDropdown.tsx
+++ b/grove-web/src/components/Blitz/ChatPickerDropdown.tsx
@@ -1,0 +1,200 @@
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
+import { listChats } from "../../api/tasks";
+import type { BlitzTask } from "../../data/types";
+import type { SlotAssignment } from "./useBlitzGrid";
+
+interface ChatPickerDropdownProps {
+  blitzTasks: BlitzTask[];
+  onSelect: (assignment: SlotAssignment) => void;
+  onClose: () => void;
+}
+
+type ChatRow = { id: string; name: string };
+type ChatLoadState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "loaded"; chats: ChatRow[] }
+  | { kind: "error"; message: string };
+
+export function ChatPickerDropdown({ blitzTasks, onSelect, onClose }: ChatPickerDropdownProps) {
+  const [query, setQuery] = useState("");
+  const [expandedTaskKey, setExpandedTaskKey] = useState<string | null>(null);
+  const [chatLoads, setChatLoads] = useState<Record<string, ChatLoadState>>({});
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function onDocClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [onClose]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return blitzTasks;
+    return blitzTasks.filter((bt) => bt.task.name.toLowerCase().includes(q));
+  }, [blitzTasks, query]);
+
+  const grouped = useMemo(() => {
+    const m = new Map<string, { projectId: string; projectName: string; tasks: BlitzTask[] }>();
+    for (const bt of filtered) {
+      const g = m.get(bt.projectId);
+      if (g) g.tasks.push(bt);
+      else m.set(bt.projectId, { projectId: bt.projectId, projectName: bt.projectName, tasks: [bt] });
+    }
+    return Array.from(m.values());
+  }, [filtered]);
+
+  function taskKey(bt: BlitzTask): string {
+    return `${bt.projectId}:${bt.task.id}`;
+  }
+
+  const fetchChats = useCallback(async (bt: BlitzTask) => {
+    const key = taskKey(bt);
+    setChatLoads((prev) => ({ ...prev, [key]: { kind: "loading" } }));
+    try {
+      const chats = await listChats(bt.projectId, bt.task.id);
+      if (!mountedRef.current) return;
+      setChatLoads((prev) => ({
+        ...prev,
+        [key]: { kind: "loaded", chats: chats.map((c) => ({ id: c.id, name: c.title })) },
+      }));
+    } catch (err) {
+      if (!mountedRef.current) return;
+      const message = err instanceof Error ? err.message : "Failed to load chats";
+      setChatLoads((prev) => ({ ...prev, [key]: { kind: "error", message } }));
+    }
+  }, []);
+
+  const toggleExpand = useCallback(async (bt: BlitzTask) => {
+    const key = taskKey(bt);
+    if (expandedTaskKey === key) {
+      setExpandedTaskKey(null);
+      return;
+    }
+    setExpandedTaskKey(key);
+    const existing = chatLoads[key];
+    if (existing && existing.kind !== "idle" && existing.kind !== "error") return;
+    await fetchChats(bt);
+  }, [expandedTaskKey, chatLoads, fetchChats]);
+
+  function pickChat(bt: BlitzTask, chat: ChatRow) {
+    onSelect({
+      projectId: bt.projectId,
+      projectName: bt.projectName,
+      taskId: bt.task.id,
+      taskName: bt.task.name,
+      chatId: chat.id,
+      chatName: chat.name,
+    });
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      role="dialog"
+      aria-modal={false}
+      aria-label="Pick a chat"
+      className="absolute z-50 mt-1 w-80 max-h-96 bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-md shadow-xl overflow-hidden flex flex-col"
+    >
+      <div className="p-2 border-b border-[var(--color-border)]">
+        <input
+          ref={inputRef}
+          type="text"
+          aria-label="Search tasks"
+          placeholder="Search tasks…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="w-full px-2 py-1 text-sm bg-[var(--color-bg)] border border-[var(--color-border)] rounded text-[var(--color-text)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)]"
+        />
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {grouped.length === 0 ? (
+          <div className="p-4 text-sm text-[var(--color-text-muted)] text-center">No tasks</div>
+        ) : (
+          grouped.map((g) => (
+            <div key={g.projectId}>
+              <div className="px-3 py-1 text-xs uppercase tracking-wider text-[var(--color-text-muted)] bg-[var(--color-bg-tertiary)]">
+                {g.projectName}
+              </div>
+              {g.tasks.map((bt) => {
+                const key = taskKey(bt);
+                const expanded = expandedTaskKey === key;
+                const load = chatLoads[key];
+                return (
+                  <div key={key}>
+                    {/* eslint-disable react-hooks/refs */}
+                    <button
+                      type="button"
+                      onClick={() => void toggleExpand(bt)}
+                      aria-expanded={expanded}
+                      className="w-full text-left px-3 py-1.5 text-sm text-[var(--color-text)] hover:brightness-125 flex items-center justify-between"
+                    >
+                      <span className="truncate">{bt.task.name}</span>
+                      <span className="text-[var(--color-text-muted)] text-xs ml-2">{expanded ? "▾" : "▸"}</span>
+                    </button>
+                    {/* eslint-enable react-hooks/refs */}
+                    {expanded && (
+                      <div className="pl-6 pr-3 pb-2 bg-[var(--color-bg)]">
+                        {(!load || load.kind === "idle" || load.kind === "loading") ? (
+                          <div className="py-1 text-xs text-[var(--color-text-muted)]">Loading chats…</div>
+                        ) : load.kind === "error" ? (
+                          <div className="py-1 text-xs text-[var(--color-error)] flex items-center justify-between">
+                            <span>{load.message}</span>
+                            <button
+                              type="button"
+                              onClick={() => void fetchChats(bt)}
+                              className="ml-2 underline text-[var(--color-text-muted)]"
+                            >
+                              Retry
+                            </button>
+                          </div>
+                        ) : load.chats.length === 0 ? (
+                          <div className="py-1 text-xs text-[var(--color-text-muted)]">No chats in this task</div>
+                        ) : (
+                          load.chats.map((c) => (
+                            <button
+                              key={c.id}
+                              type="button"
+                              onClick={() => pickChat(bt, c)}
+                              className="w-full text-left py-1 text-xs text-[var(--color-text)] hover:underline truncate"
+                            >
+                              {c.name}
+                            </button>
+                          ))
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/grove-web/src/components/Blitz/SessionPickerPane.tsx
+++ b/grove-web/src/components/Blitz/SessionPickerPane.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "react";
+import { X } from "lucide-react";
+import { listChats } from "../../api/tasks";
+
+interface SessionPickerPaneProps {
+  projectId: string;
+  taskId: string;
+  taskName: string;
+  /** Called with the chosen session; the dropped panel becomes that chat. */
+  onPick: (chat: { id: string; name: string }) => void;
+  /** Called when the user dismisses without picking (closes the panel). */
+  onCancel: () => void;
+}
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "error"; message: string }
+  | { kind: "ready"; chats: Array<{ id: string; name: string; agent: string }> };
+
+/**
+ * Shown inside a freshly-dropped panel (a task dragged from the left list)
+ * until the user picks which of that task's chat sessions to pin. The pick is
+ * the confirmation — no separate modal.
+ */
+export function SessionPickerPane({ projectId, taskId, taskName, onPick, onCancel }: SessionPickerPaneProps) {
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+
+  useEffect(() => {
+    // Each pane is bound to one task, so projectId/taskId don't change over its
+    // lifetime — the initial "loading" state covers the single fetch. (Avoid a
+    // synchronous setState here per react-hooks/set-state-in-effect.)
+    let cancelled = false;
+    listChats(projectId, taskId)
+      .then((chats) => {
+        if (cancelled) return;
+        setState({
+          kind: "ready",
+          chats: chats.map((c) => ({ id: c.id, name: c.title || "Untitled chat", agent: c.agent })),
+        });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setState({ kind: "error", message: err instanceof Error ? err.message : "Failed to load sessions" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, taskId]);
+
+  return (
+    <div className="flex flex-col h-full w-full min-h-0 bg-[var(--color-bg)]">
+      <div className="flex items-center justify-between gap-2 shrink-0 px-3 py-2 border-b border-[var(--color-border)]">
+        <div className="min-w-0">
+          <div className="text-sm font-medium truncate text-[var(--color-text)]">{taskName}</div>
+          <div className="text-[11px] text-[var(--color-text-muted)]">Pick a session to pin</div>
+        </div>
+        <button
+          type="button"
+          onClick={onCancel}
+          aria-label="Cancel"
+          className="shrink-0 p-1 rounded text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-tertiary)] transition-colors"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+      <div className="flex-1 min-h-0 overflow-auto">
+        {state.kind === "loading" && (
+          <div className="p-4 text-sm text-[var(--color-text-muted)]">Loading sessions…</div>
+        )}
+        {state.kind === "error" && (
+          <div className="p-4 text-sm text-[var(--color-error)]">{state.message}</div>
+        )}
+        {state.kind === "ready" && state.chats.length === 0 && (
+          <div className="p-4 text-sm text-[var(--color-text-muted)]">No chat sessions in this task yet.</div>
+        )}
+        {state.kind === "ready" &&
+          state.chats.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              onClick={() => onPick({ id: c.id, name: c.name })}
+              className="w-full flex items-center justify-between gap-2 px-3 py-2.5 text-left border-b border-[var(--color-border)] hover:bg-[var(--color-highlight)]/10 transition-colors"
+            >
+              <span className="min-w-0">
+                <span className="block text-sm truncate text-[var(--color-text)]">{c.name}</span>
+                <span className="block text-[11px] text-[var(--color-text-muted)]">{c.agent}</span>
+              </span>
+              <span className="shrink-0 text-[11px] font-medium text-[var(--color-highlight)]">pin →</span>
+            </button>
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/grove-web/src/components/Blitz/blitzFlexModel.ts
+++ b/grove-web/src/components/Blitz/blitzFlexModel.ts
@@ -1,0 +1,250 @@
+/**
+ * Model + persistence + migration for the Blitz FlexLayout workspace.
+ *
+ * Each FlexLayout tab is one pinned chat. The tab's `config` carries the
+ * full coordinates ({project, task, chat}) so the factory can render the
+ * right `<TaskChat pinnedChatId>` per tab — unlike the single-task
+ * FlexLayoutContainer whose factory hardcodes one task.
+ *
+ * Storage:
+ *   - New: `grove:blitz-flexlayout` holds the serialized IJsonModel.
+ *   - Legacy: `grove:blitz-grid` (the fixed-preset grid) is migrated once
+ *     into the new model so existing users keep their panes, then left in
+ *     place as a harmless fallback.
+ */
+import { Model } from "flexlayout-react";
+import type { IJsonModel, IJsonRowNode, IJsonTabSetNode, IJsonTabNode } from "flexlayout-react";
+import type { GridLayout, SlotAssignment } from "./useBlitzGrid";
+
+export const BLITZ_FLEX_STORAGE_KEY = "grove:blitz-flexlayout";
+const LEGACY_GRID_STORAGE_KEY = "grove:blitz-grid";
+
+/** Per-tab config — the full coordinates of a pinned chat. */
+export interface BlitzTabConfig {
+  projectId: string;
+  projectName: string;
+  taskId: string;
+  taskName: string;
+  /** Absent while `needsSession` (a dropped task awaiting a session pick). */
+  chatId?: string;
+  chatName?: string;
+  /** True between a task-drop and the user choosing a session (Phase 2). */
+  needsSession?: boolean;
+}
+
+export const BLITZ_TAB_COMPONENT = "blitz-chat";
+
+/** dataTransfer MIME a dragged task carries so the canvas can accept it. */
+export const GROVE_TASK_MIME = "application/x-grove-task";
+
+const GLOBAL: IJsonModel["global"] = {
+  tabEnableClose: true,
+  tabEnableRename: false,
+  tabSetEnableDeleteWhenEmpty: true,
+  tabSetEnableDrop: true,
+  tabSetEnableDrag: true,
+  tabSetEnableDivide: true,
+  tabSetEnableMaximize: true,
+  splitterSize: 6,
+};
+
+function emptyModel(): IJsonModel {
+  return { global: GLOBAL, borders: [], layout: { type: "row", weight: 100, children: [] } };
+}
+
+/**
+ * Build a tab node from a pinned-chat config. Intentionally omits `id` so
+ * FlexLayout generates a unique one — deriving the id from chatId would throw
+ * `duplicate id` if the same chat were pinned twice. We identify a chat's tab
+ * by `config.chatId` instead (see addChat / migration dedup).
+ */
+export function tabNodeFor(cfg: BlitzTabConfig): IJsonTabNode {
+  return {
+    type: "tab",
+    name: cfg.chatName || cfg.taskName,
+    component: BLITZ_TAB_COMPONENT,
+    config: cfg,
+    enableClose: true,
+  };
+}
+
+function tabSetWith(cfg: BlitzTabConfig): IJsonTabSetNode {
+  return { type: "tabset", weight: 100, children: [tabNodeFor(cfg)] };
+}
+
+/** Like tabNodeFor but preserves an existing tab id (used when re-tiling so
+ *  panels keep their identity and chats don't remount/reconnect). */
+function tabNodeWithId(id: string, cfg: BlitzTabConfig): IJsonTabNode {
+  return {
+    type: "tab",
+    id,
+    name: cfg.chatName || cfg.taskName,
+    component: BLITZ_TAB_COMPONENT,
+    config: cfg,
+    enableClose: true,
+  };
+}
+
+/** A currently-open tab: its FlexLayout-generated id + pinned-chat config. */
+export interface OpenTab {
+  id: string;
+  config: BlitzTabConfig;
+}
+
+/**
+ * Rebuild the model laying the given tabs into `cols` balanced columns
+ * (round-robin so columns stay even), equal weights throughout. Each tab keeps
+ * its existing id, so swapping to this model reconciles the panels rather than
+ * remounting them — pinned chats stay connected across a re-tile.
+ */
+export function buildColumnsModelJson(tabs: OpenTab[], cols: number): IJsonModel {
+  if (tabs.length === 0) return emptyModel();
+  const colCount = Math.max(1, Math.min(cols, tabs.length));
+  const columns: OpenTab[][] = Array.from({ length: colCount }, () => []);
+  tabs.forEach((t, i) => columns[i % colCount].push(t));
+  const children = columns
+    .filter((col) => col.length > 0)
+    .map((col) => {
+      const tabsets: IJsonTabSetNode[] = col.map((t) => ({
+        type: "tabset",
+        weight: 100,
+        children: [tabNodeWithId(t.id, t.config)],
+      }));
+      return tabsets.length === 1
+        ? tabsets[0]
+        : ({ type: "row", weight: 100, children: tabsets } as IJsonRowNode);
+    });
+  return { global: GLOBAL, borders: [], layout: { type: "row", weight: 100, children } };
+}
+
+/** Columns × rows for each legacy preset. */
+function shapeFor(layout: GridLayout): { cols: number; rows: number } {
+  switch (layout) {
+    case "1": return { cols: 1, rows: 1 };
+    case "2": return { cols: 2, rows: 1 };
+    case "2x2": return { cols: 2, rows: 2 };
+    case "3x2": return { cols: 3, rows: 2 };
+  }
+}
+
+/**
+ * Recreate a layout tree from legacy grid assignments. Non-null assignments
+ * are chunked into columns of `rows` tabsets each, approximating the old
+ * grid shape (a full 2×2 reconstructs exactly; gaps compact). FlexLayout
+ * alternates orientation by nesting depth, so the root row is horizontal and
+ * each child row stacks its tabsets vertically.
+ */
+function layoutFromAssignments(
+  assignments: Array<SlotAssignment | null>,
+  layout: GridLayout,
+): IJsonRowNode {
+  // Dedup by chatId — legacy state could pin the same chat in multiple slots,
+  // which would otherwise produce duplicate panels (and previously crashed on
+  // duplicate node ids). Keep the first occurrence.
+  const seen = new Set<string>();
+  const items = assignments
+    .filter((a): a is SlotAssignment => a !== null)
+    .filter((a) => (seen.has(a.chatId) ? false : (seen.add(a.chatId), true)));
+  if (items.length === 0) return { type: "row", weight: 100, children: [] };
+
+  const { rows } = shapeFor(layout);
+  const columns: IJsonTabSetNode[][] = [];
+  items.forEach((item, i) => {
+    const col = Math.floor(i / rows);
+    (columns[col] ??= []).push(tabSetWith(item));
+  });
+
+  const children = columns.map((col) =>
+    col.length === 1 ? col[0] : ({ type: "row", weight: 100, children: col } as IJsonRowNode),
+  );
+  return { type: "row", weight: 100, children };
+}
+
+function migrateLegacy(raw: string): IJsonModel | null {
+  let parsed: { layout?: GridLayout; assignments?: Array<SlotAssignment | null> };
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const layout: GridLayout = parsed.layout ?? "2x2";
+  const assignments = Array.isArray(parsed.assignments) ? parsed.assignments : [];
+  const tree = layoutFromAssignments(assignments, layout);
+  if (tree.children.length === 0) return null;
+  return { global: GLOBAL, borders: [], layout: tree };
+}
+
+/** Recursively drop the transient `maximized` flag before persisting. */
+function stripMaximized(node: { maximized?: boolean; children?: unknown[] }): void {
+  if (node.maximized) delete node.maximized;
+  if (Array.isArray(node.children)) {
+    for (const c of node.children) stripMaximized(c as { maximized?: boolean; children?: unknown[] });
+  }
+}
+
+function parseSavedJson(raw: string): IJsonModel | null {
+  try {
+    const json = JSON.parse(raw) as IJsonModel;
+    if (!json.global) json.global = GLOBAL;
+    return json;
+  } catch {
+    return null;
+  }
+}
+
+/** Construct a Model from JSON, returning null instead of throwing on invalid
+ *  data (e.g. duplicate ids from a previous buggy write). */
+function safeModel(json: IJsonModel | null): Model | null {
+  if (!json) return null;
+  try {
+    return Model.fromJson(json);
+  } catch (err) {
+    console.warn("[blitzFlex] discarding invalid layout", err);
+    return null;
+  }
+}
+
+/**
+ * Build the initial Model: saved → migrated-from-legacy → empty. Never throws —
+ * a corrupt saved layout is validated, discarded, and removed so grid mode
+ * can't be bricked by bad localStorage.
+ */
+export function createInitialModel(): Model {
+  if (typeof window !== "undefined") {
+    try {
+      const saved = window.localStorage.getItem(BLITZ_FLEX_STORAGE_KEY);
+      if (saved) {
+        const m = safeModel(parseSavedJson(saved));
+        if (m) return m;
+        try {
+          window.localStorage.removeItem(BLITZ_FLEX_STORAGE_KEY);
+        } catch {
+          /* ignore */
+        }
+      }
+    } catch (err) {
+      console.warn("[blitzFlex] failed to read saved layout", err);
+    }
+    try {
+      const legacy = window.localStorage.getItem(LEGACY_GRID_STORAGE_KEY);
+      if (legacy) {
+        const m = safeModel(migrateLegacy(legacy));
+        if (m) return m;
+      }
+    } catch (err) {
+      console.warn("[blitzFlex] legacy migration failed", err);
+    }
+  }
+  return Model.fromJson(emptyModel());
+}
+
+/** Serialize + persist a model's JSON to localStorage (maximized stripped). */
+export function persistModelJson(json: IJsonModel): void {
+  if (typeof window === "undefined") return;
+  try {
+    stripMaximized(json.layout);
+    window.localStorage.setItem(BLITZ_FLEX_STORAGE_KEY, JSON.stringify(json));
+  } catch (err) {
+    console.warn("[blitzFlex] failed to persist layout", err);
+  }
+}

--- a/grove-web/src/components/Blitz/useBlitzGrid.ts
+++ b/grove-web/src/components/Blitz/useBlitzGrid.ts
@@ -1,0 +1,167 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+
+export type GridLayout = "1" | "2" | "2x2" | "3x2";
+
+export const GRID_LAYOUTS: ReadonlyArray<GridLayout> = ["1", "2", "2x2", "3x2"];
+
+export function slotCountFor(layout: GridLayout): number {
+  switch (layout) {
+    case "1": return 1;
+    case "2": return 2;
+    case "2x2": return 4;
+    case "3x2": return 6;
+  }
+}
+
+export interface SlotAssignment {
+  projectId: string;
+  projectName: string;
+  taskId: string;
+  taskName: string;
+  chatId: string;
+  chatName: string;
+}
+
+export interface BlitzGridState {
+  version: 1;
+  layout: GridLayout;
+  assignments: Array<SlotAssignment | null>;
+}
+
+const STORAGE_KEY = "grove:blitz-grid";
+const DEFAULT_LAYOUT: GridLayout = "2x2";
+const PERSIST_DEBOUNCE_MS = 200;
+
+function defaultState(): BlitzGridState {
+  return {
+    version: 1,
+    layout: DEFAULT_LAYOUT,
+    assignments: new Array(slotCountFor(DEFAULT_LAYOUT)).fill(null),
+  };
+}
+
+function hydrate(): BlitzGridState {
+  if (typeof window === "undefined") return defaultState();
+  let raw: string | null;
+  try {
+    raw = window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return defaultState();
+  }
+  if (!raw) return defaultState();
+  try {
+    const parsed = JSON.parse(raw) as Partial<BlitzGridState>;
+    const layout: GridLayout =
+      typeof parsed.layout === "string" && (GRID_LAYOUTS as readonly string[]).includes(parsed.layout)
+        ? (parsed.layout as GridLayout)
+        : DEFAULT_LAYOUT;
+    const expectedCount = slotCountFor(layout);
+    const rawAssignments = Array.isArray(parsed.assignments) ? parsed.assignments : [];
+    const assignments: Array<SlotAssignment | null> = new Array(expectedCount)
+      .fill(null)
+      .map((_, i) => {
+        const a = rawAssignments[i];
+        if (
+          a &&
+          typeof a === "object" &&
+          typeof (a as SlotAssignment).projectId === "string" &&
+          typeof (a as SlotAssignment).projectName === "string" &&
+          typeof (a as SlotAssignment).taskId === "string" &&
+          typeof (a as SlotAssignment).taskName === "string" &&
+          typeof (a as SlotAssignment).chatId === "string" &&
+          typeof (a as SlotAssignment).chatName === "string"
+        ) {
+          return a as SlotAssignment;
+        }
+        return null;
+      });
+    return { version: 1, layout, assignments };
+  } catch {
+    return defaultState();
+  }
+}
+
+export interface UseBlitzGridResult {
+  layout: GridLayout;
+  assignments: Array<SlotAssignment | null>;
+  setLayout: (next: GridLayout) => void;
+  assign: (slotIdx: number, assignment: SlotAssignment) => void;
+  clearSlot: (slotIdx: number) => void;
+}
+
+export function useBlitzGrid(): UseBlitzGridResult {
+  const [state, setState] = useState<BlitzGridState>(hydrate);
+  const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestStateRef = useRef(state);
+  useEffect(() => {
+    latestStateRef.current = state;
+  }, [state]);
+
+  useEffect(() => {
+    if (persistTimerRef.current !== null) {
+      clearTimeout(persistTimerRef.current);
+    }
+    persistTimerRef.current = setTimeout(() => {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+      } catch (err) {
+        console.warn("[useBlitzGrid] localStorage write failed", err);
+      }
+    }, PERSIST_DEBOUNCE_MS);
+    return () => {
+      if (persistTimerRef.current !== null) {
+        clearTimeout(persistTimerRef.current);
+      }
+    };
+  }, [state]);
+
+  useEffect(() => {
+    return () => {
+      // Cleanup-on-unmount: flush the latest state synchronously so a
+      // change made within the debounce window is not lost when the
+      // component unmounts (e.g., user toggles grid view off in Blitz).
+      try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(latestStateRef.current));
+      } catch (err) {
+        console.warn("[useBlitzGrid] unmount flush failed", err);
+      }
+    };
+  }, []);
+
+  const setLayout = useCallback((next: GridLayout) => {
+    setState((prev) => {
+      const nextCount = slotCountFor(next);
+      const nextAssignments = new Array<SlotAssignment | null>(nextCount).fill(null);
+      for (let i = 0; i < Math.min(prev.assignments.length, nextCount); i++) {
+        nextAssignments[i] = prev.assignments[i];
+      }
+      return { ...prev, layout: next, assignments: nextAssignments };
+    });
+  }, []);
+
+  const assign = useCallback((slotIdx: number, assignment: SlotAssignment) => {
+    setState((prev) => {
+      if (slotIdx < 0 || slotIdx >= prev.assignments.length) return prev;
+      const nextAssignments = prev.assignments.slice();
+      nextAssignments[slotIdx] = assignment;
+      return { ...prev, assignments: nextAssignments };
+    });
+  }, []);
+
+  const clearSlot = useCallback((slotIdx: number) => {
+    setState((prev) => {
+      if (slotIdx < 0 || slotIdx >= prev.assignments.length) return prev;
+      const nextAssignments = prev.assignments.slice();
+      nextAssignments[slotIdx] = null;
+      return { ...prev, assignments: nextAssignments };
+    });
+  }, []);
+
+  return {
+    layout: state.layout,
+    assignments: state.assignments,
+    setLayout,
+    assign,
+    clearSlot,
+  };
+}

--- a/grove-web/src/components/Config/ShortcutEditModal.tsx
+++ b/grove-web/src/components/Config/ShortcutEditModal.tsx
@@ -58,6 +58,7 @@ const KNOWN_CONTEXT_KEYS: { name: string; description: string }[] = [
   { name: "messageNotEmpty", description: "Chat message has content" },
   { name: "taskNameValid", description: "New-task name passes validation" },
   { name: "inBlitzMode", description: "Blitz mode is active" },
+  { name: "blitzGridActive", description: "Blitz grid workspace is showing" },
   { name: "inZenMode", description: "Zen mode is active" },
 ];
 

--- a/grove-web/src/components/Tasks/TaskView/TaskChat.tsx
+++ b/grove-web/src/components/Tasks/TaskView/TaskChat.tsx
@@ -268,6 +268,12 @@ function gcChatDraftsOnce(): void {
 interface TaskChatProps {
   projectId: string;
   task: Task;
+  /** If provided, the chat with this id is pinned as the active chat
+   *  and the chat-switcher tab UI is hidden. Used by the Blitz grid
+   *  workspace to scope each slot to a single chat. Omitted in Zen
+   *  mode and the single-task Blitz workspace (preserves existing
+   *  multi-chat tab behavior). */
+  pinnedChatId?: string;
   collapsed?: boolean;
   onExpand?: () => void;
   onCollapse?: () => void;
@@ -1917,6 +1923,7 @@ function DownloadingLabel({ startedAt, compact }: { startedAt: number; compact?:
 export function TaskChat({
   projectId,
   task,
+  pinnedChatId,
   collapsed = false,
   onExpand,
   onCollapse,
@@ -1952,7 +1959,7 @@ export function TaskChat({
     activeChatId,
     getActiveChatId,
     setActiveChatId,
-  } = useActiveChatId(null);
+  } = useActiveChatId(pinnedChatId ?? null);
   useReportDebugId("chatId", activeChatId);
 
   // Voice control context contribution for active chat sessions
@@ -3493,6 +3500,7 @@ export function TaskChat({
     taskId: task.id,
     setChats,
     setActiveChatId,
+    pinnedChatId,
   });
 
   // Restore the composer draft on initial mount.
@@ -3575,7 +3583,9 @@ export function TaskChat({
         if (pendingMatches && pending) {
           const targetId = pending.chatId;
           delete (window as unknown as Record<string, unknown>).__grove_pending_chat;
-          setActiveChatId(targetId);
+          if (!pinnedChatId) {
+            setActiveChatId(targetId);
+          }
           writeLastActiveTab("chat", projectId, task.id, targetId);
           restoreChatState(targetId);
           await connectChatWsRef.current(targetId);
@@ -3588,13 +3598,17 @@ export function TaskChat({
 
         const next = fresh[fresh.length - 1];
         if (next) {
-          setActiveChatId(next.id);
+          if (!pinnedChatId) {
+            setActiveChatId(next.id);
+          }
           writeLastActiveTab("chat", projectId, task.id, next.id);
           restoreChatState(next.id);
           await connectChatWsRef.current(next.id);
           wsRef.current = wsMapRef.current.get(next.id) ?? null;
         } else {
-          setActiveChatId(null);
+          if (!pinnedChatId) {
+            setActiveChatId(null);
+          }
           restoreChatState("__deleted__");
           wsRef.current = null;
         }
@@ -4697,6 +4711,11 @@ export function TaskChat({
 
   const switchChat = useCallback(
     async (chatId: string) => {
+      // Pinned mode (Blitz grid slot): chat switching is suppressed —
+      // the slot is locked to a single chat. Both user-driven and
+      // automatic callers (post-new-chat, grove:switch-chat event,
+      // grove:select-chat event) become no-ops here so the pin holds.
+      if (pinnedChatId) return;
       if (chatId === activeChatId) return;
       perfMark("TaskChat:switchChat", { from: activeChatId, to: chatId });
       saveCurrentChatState();
@@ -4708,7 +4727,7 @@ export function TaskChat({
       await connectChatWs(chatId);
       wsRef.current = wsMapRef.current.get(chatId) ?? null;
     },
-    [activeChatId, projectId, task.id, saveCurrentChatState, restoreChatState, connectChatWs, setActiveChatId],
+    [pinnedChatId, activeChatId, projectId, task.id, saveCurrentChatState, restoreChatState, connectChatWs, setActiveChatId],
   );
   useEffect(() => {
     switchChatRef.current = switchChat;
@@ -4831,7 +4850,9 @@ export function TaskChat({
           const updated = prev.filter((c) => c.id !== chatId);
           if (chatId === activeChatId && updated.length > 0) {
             const next = updated[updated.length - 1];
-            setActiveChatId(next.id);
+            if (!pinnedChatId) {
+              setActiveChatId(next.id);
+            }
             writeLastActiveTab("chat", projectId, task.id, next.id);
             restoreChatState(next.id);
           }
@@ -4842,7 +4863,7 @@ export function TaskChat({
       }
       setShowChatMenu(false);
     },
-    [chats.length, projectId, task.id, activeChatId, restoreChatState, setActiveChatId],
+    [chats.length, projectId, task.id, activeChatId, pinnedChatId, restoreChatState, setActiveChatId],
   );
 
   // ─── Chat fork ─────────────────────────────────────────────────────────
@@ -4854,7 +4875,9 @@ export function TaskChat({
       try {
         const created = await forkChat(projectId, task.id, chatId);
         setChats((prev) => [...prev, created]);
-        setActiveChatId(created.id);
+        if (!pinnedChatId) {
+          setActiveChatId(created.id);
+        }
         writeLastActiveTab("chat", projectId, task.id, created.id);
         restoreChatState(created.id);
       } catch (err) {
@@ -4870,7 +4893,7 @@ export function TaskChat({
       }
       setShowChatMenu(false);
     },
-    [projectId, task.id, restoreChatState, setActiveChatId],
+    [projectId, task.id, pinnedChatId, restoreChatState, setActiveChatId],
   );
 
   // ─── User actions ────────────────────────────────────────────────────────
@@ -5686,16 +5709,27 @@ export function TaskChat({
   // keybindings in onKeyDown still own composer-local semantics (Enter vs
   // Shift+Enter inside contenteditable) — these registry entries only
   // surface for catalog binding overrides + palette discovery.
+  // Multiple TaskChats coexist in the Blitz grid, and each registers
+  // `chat.send`. The command registry now keeps every handler and dispatches
+  // to the first whose `enabled()` passes, so we gate on "is focus inside THIS
+  // panel?" (same guard as chat.search.toggle) to route Enter to the focused
+  // pane. Without it, Enter sent to whichever chat mounted last. In single-pane
+  // Zen the only instance is the focused one, so behaviour is unchanged.
+  const sendFocusInPanel = () => {
+    const root = taskChatRootRef.current;
+    const active = document.activeElement;
+    return !!(root && active && root.contains(active));
+  };
   useCommand(
     "chat.send",
     () => { void handleSend(); },
-    { enabled: () => !!activeChatId && !showFileMenu && !showSlashMenu && !isInputExpanded },
+    { enabled: () => sendFocusInPanel() && !!activeChatId && !showFileMenu && !showSlashMenu && !isInputExpanded },
     [activeChatId, showFileMenu, showSlashMenu, isInputExpanded, handleSend],
   );
   useCommand(
     "chat.send.alt",
     () => { void handleSend(); },
-    { enabled: () => !!activeChatId && !showFileMenu && !showSlashMenu },
+    { enabled: () => sendFocusInPanel() && !!activeChatId && !showFileMenu && !showSlashMenu },
     [activeChatId, showFileMenu, showSlashMenu, handleSend],
   );
   useCommand(
@@ -6877,11 +6911,31 @@ export function TaskChat({
         }
         return;
       }
-      // Enter / Cmd+Enter → send moved to the catalog (chat.send /
-      // chat.send.alt) so the binding is rebindable in Settings.
-      // KeyboardManager handles them via passThroughTextInput.
+      // Enter / Cmd+Enter → send. In single-pane (Zen) this rides the
+      // `chat.send` / `chat.send.alt` catalog commands (scope "workspace",
+      // rebindable in Settings). The Blitz grid mounts TaskChat directly and
+      // never activates the "workspace" scope — and its `chatFocus` /
+      // `messageNotEmpty` context keys are clobbered across the 4 panes — so
+      // the catalog binding can't fire there. When pinned (grid only) we handle
+      // Enter locally on the focused composer instead. Gating on pinnedChatId
+      // keeps single-pane on the catalog path (no double-send).
+      if (pinnedChatId && !isTerminalMode && !showFileMenu && !showSlashMenu && e.key === "Enter") {
+        const withMod = e.metaKey || e.ctrlKey;
+        // Plain Enter sends unless the input is expanded (then Enter = newline);
+        // Cmd/Ctrl+Enter always sends (mirrors chat.send.alt). Shift+Enter is
+        // always a newline.
+        if (!e.shiftKey && (withMod || !isInputExpanded)) {
+          e.preventDefault();
+          e.stopPropagation();
+          e.nativeEvent.stopImmediatePropagation();
+          void handleSend();
+          return;
+        }
+      }
     },
     [
+      pinnedChatId,
+      handleSend,
       isTerminalMode,
       isInputExpanded,
       showSlashMenu,
@@ -7244,7 +7298,7 @@ export function TaskChat({
                     </button>
                   )}
 
-                  {showChatMenu && (
+                  {!pinnedChatId && showChatMenu && (
                     <div className="absolute top-full left-0 z-[80] mt-1 min-w-56 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] shadow-lg">
                       <div className="border-b border-[color-mix(in_srgb,var(--color-border)_72%,transparent)] bg-[var(--color-bg)] px-2 py-1">
                         <button
@@ -7478,7 +7532,7 @@ export function TaskChat({
                     </button>
                   )}
                 </div>
-                {orderedChats.map((chat) => {
+                {!pinnedChatId && orderedChats.map((chat) => {
                   const ChatIcon = getChatIcon(chat.agent);
                   const isActive = chat.id === activeChatId;
                   return (

--- a/grove-web/src/components/Tasks/TaskView/useInitialChatLoad.ts
+++ b/grove-web/src/components/Tasks/TaskView/useInitialChatLoad.ts
@@ -17,6 +17,11 @@ interface Params {
   taskId: string;
   setChats: (chats: ChatSessionResponse[]) => void;
   setActiveChatId: (id: string) => void;
+  /** If provided, the parent has pinned a specific chat (Blitz grid
+   *  slot). Skip the active-chat-restoration logic so the pinned
+   *  chat (already set by useState seed) remains active. We still
+   *  load and publish the chat list via setChats. */
+  pinnedChatId?: string;
 }
 
 /**
@@ -32,6 +37,7 @@ export function useInitialChatLoad({
   taskId,
   setChats,
   setActiveChatId,
+  pinnedChatId,
 }: Params): void {
   useEffect(() => {
     let cancelled = false;
@@ -62,6 +68,12 @@ export function useInitialChatLoad({
       }
       if (cancelled) return;
       setChats(chatList);
+      if (pinnedChatId) {
+        // Pinned mode (Blitz grid slot): parent has already seeded
+        // activeChatId from pinnedChatId via useState. Skip the
+        // pending-match / last-tab restoration logic so the pin sticks.
+        return;
+      }
       const win = window as unknown as Record<string, unknown>;
       const pending = win.__grove_pending_chat as
         | { projectId: string; taskId: string; chatId: string }
@@ -97,5 +109,5 @@ export function useInitialChatLoad({
     return () => {
       cancelled = true;
     };
-  }, [projectId, taskId, setChats, setActiveChatId]);
+  }, [projectId, taskId, setChats, setActiveChatId, pinnedChatId]);
 }

--- a/grove-web/src/keyboard/CommandRegistry.ts
+++ b/grove-web/src/keyboard/CommandRegistry.ts
@@ -25,7 +25,13 @@ interface HandlerEntry {
 export class CommandRegistryImpl {
   private staticCatalog: Map<string, CommandDef> = new Map();
   private contributed: Map<string, CommandDef> = new Map();
-  private handlers: Map<string, HandlerEntry> = new Map();
+  // A command id can have MORE THAN ONE handler registered at once — e.g. the
+  // Blitz grid mounts several TaskChat instances, each registering `chat.send`.
+  // We keep them all (most-recent last) and, at invoke time, dispatch to the
+  // first whose `enabled()` gate passes. That lets a per-instance focus guard
+  // (does this panel contain document.activeElement?) route the key to the
+  // focused pane instead of an arbitrary last-write-wins winner.
+  private handlers: Map<string, HandlerEntry[]> = new Map();
   private listeners: Set<() => void> = new Set();
 
   setStaticCatalog(defs: ReadonlyArray<CommandDef>): void {
@@ -65,18 +71,21 @@ export class CommandRegistryImpl {
       console.warn(`[CommandRegistry] handler registered for unknown command "${id}" — declare it in catalog or use useDefineCommand`);
     }
     const entry: HandlerEntry = { handler, enabled };
-    const prev = this.handlers.get(id);
-    if (prev) {
-      console.warn(`[CommandRegistry] handler for "${id}" already registered — replacing`);
+    const list = this.handlers.get(id);
+    if (list) {
+      list.push(entry);
+    } else {
+      this.handlers.set(id, [entry]);
     }
-    this.handlers.set(id, entry);
     this.notify();
     return () => {
       const current = this.handlers.get(id);
-      if (current === entry) {
-        this.handlers.delete(id);
-        this.notify();
-      }
+      if (!current) return;
+      const idx = current.indexOf(entry);
+      if (idx === -1) return;
+      current.splice(idx, 1);
+      if (current.length === 0) this.handlers.delete(id);
+      this.notify();
     };
   }
 
@@ -85,18 +94,25 @@ export class CommandRegistryImpl {
    * handler was registered or the enabled gate said no.
    */
   invoke(id: string, args?: unknown): boolean {
-    const entry = this.handlers.get(id);
-    if (!entry) return false;
-    if (entry.enabled && !entry.enabled()) return false;
-    try {
-      const r = entry.handler(args);
-      if (r instanceof Promise) {
-        r.catch((e) => console.error(`[CommandRegistry] "${id}" async failed:`, e));
+    const list = this.handlers.get(id);
+    if (!list || list.length === 0) return false;
+    // Most-recently-registered first. Run the first handler whose enabled
+    // gate passes; a focus-guarded gate (see TaskChat chat.send) means the
+    // focused pane wins. With a single handler this is the old behaviour.
+    for (let i = list.length - 1; i >= 0; i--) {
+      const entry = list[i];
+      if (entry.enabled && !entry.enabled()) continue;
+      try {
+        const r = entry.handler(args);
+        if (r instanceof Promise) {
+          r.catch((e) => console.error(`[CommandRegistry] "${id}" async failed:`, e));
+        }
+      } catch (e) {
+        console.error(`[CommandRegistry] "${id}" threw:`, e);
       }
-    } catch (e) {
-      console.error(`[CommandRegistry] "${id}" threw:`, e);
+      return true;
     }
-    return true;
+    return false;
   }
 
   /** Look up a CommandDef. Contributed entries shadow static (last-write-wins). */
@@ -118,9 +134,16 @@ export class CommandRegistryImpl {
     return out;
   }
 
-  /** Get the enabled predicate for a command (if any). KeybindingResolver uses this. */
+  /**
+   * Gate predicate KeyboardManager checks before firing a binding: true if ANY
+   * registered handler is currently enabled. (invoke then picks that handler.)
+   * Returns undefined when no handler is registered so the manager treats the
+   * binding as unhandled and keeps walking the scope stack.
+   */
   getEnabled(id: string): (() => boolean) | undefined {
-    return this.handlers.get(id)?.enabled;
+    const list = this.handlers.get(id);
+    if (!list || list.length === 0) return undefined;
+    return () => list.some((e) => !e.enabled || e.enabled());
   }
 
   subscribe(listener: () => void): () => void {

--- a/grove-web/src/keyboard/KeyboardManager.ts
+++ b/grove-web/src/keyboard/KeyboardManager.ts
@@ -27,6 +27,7 @@ interface ResolvedBinding {
   preventDefault: boolean;
   passThroughTextInput: boolean;
   trigger: "keydown" | "keyup";
+  ignoreRepeat: boolean;
 }
 
 function detectSuppression(): Suppression {
@@ -192,6 +193,7 @@ export class KeyboardManagerImpl {
           preventDefault: def.preventDefault !== false,
           passThroughTextInput: def.passThroughTextInput === true,
           trigger: def.trigger ?? "keydown",
+          ignoreRepeat: def.ignoreRepeat === true,
         });
       }
     }
@@ -298,6 +300,9 @@ export class KeyboardManagerImpl {
       if (r.scope !== scope) continue;
       if (r.trigger !== trigger) continue;
       if (!matchesHotkey(e, r.parsed, this.modifierSides)) continue;
+
+      // Auto-repeat (key held) is ignored for toggles and the like.
+      if (r.ignoreRepeat && e.repeat) continue;
 
       if (!r.passThroughTextInput) {
         if (suppression === "all") {

--- a/grove-web/src/keyboard/__tests__/CommandRegistry.test.ts
+++ b/grove-web/src/keyboard/__tests__/CommandRegistry.test.ts
@@ -130,9 +130,44 @@ describe("CommandRegistry", () => {
     expect(listener).not.toHaveBeenCalled();
   });
 
-  it("getEnabled returns the enabled predicate", () => {
-    const enabled = () => false;
-    reg.contribute(def("x"), vi.fn(), enabled);
-    expect(reg.getEnabled("x")).toBe(enabled);
+  it("getEnabled reflects the registered enabled predicate", () => {
+    reg.contribute(def("x"), vi.fn(), () => false);
+    expect(reg.getEnabled("x")?.()).toBe(false);
+  });
+
+  it("getEnabled is undefined when no handler is registered", () => {
+    reg.setStaticCatalog([def("a")]);
+    expect(reg.getEnabled("a")).toBeUndefined();
+  });
+
+  it("multiple handlers: invoke runs the first enabled one (most-recent first)", () => {
+    reg.setStaticCatalog([def("a")]);
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    // h1 enabled, h2 disabled — newest (h2) is skipped, h1 runs.
+    reg.registerHandler("a", h1, () => true);
+    reg.registerHandler("a", h2, () => false);
+    expect(reg.invoke("a")).toBe(true);
+    expect(h2).not.toHaveBeenCalled();
+    expect(h1).toHaveBeenCalledOnce();
+  });
+
+  it("multiple handlers: getEnabled is true if ANY handler is enabled", () => {
+    reg.setStaticCatalog([def("a")]);
+    reg.registerHandler("a", vi.fn(), () => false);
+    reg.registerHandler("a", vi.fn(), () => true);
+    expect(reg.getEnabled("a")?.()).toBe(true);
+  });
+
+  it("multiple handlers: disposing one leaves the other intact", () => {
+    reg.setStaticCatalog([def("a")]);
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    reg.registerHandler("a", h1);
+    const dispose2 = reg.registerHandler("a", h2);
+    dispose2();
+    reg.invoke("a");
+    expect(h2).not.toHaveBeenCalled();
+    expect(h1).toHaveBeenCalledOnce();
   });
 });

--- a/grove-web/src/keyboard/catalog/blitz.ts
+++ b/grove-web/src/keyboard/catalog/blitz.ts
@@ -25,6 +25,28 @@ function makeJump(n: number): CommandDef {
   };
 }
 
-export const BLITZ_COMMANDS: CommandDef[] = Array.from({ length: 10 }, (_, i) =>
-  makeJump(i + 1),
-);
+export const BLITZ_COMMANDS: CommandDef[] = [
+  ...Array.from({ length: 10 }, (_, i) => makeJump(i + 1)),
+  {
+    id: "blitz.grid.toggle",
+    name: "Toggle Grid Workspace",
+    category: "Blitz",
+    description: "Switch Blitz between the task list and the grid workspace",
+    // Mod = ⌘ on macOS, Ctrl on Linux/Windows.
+    defaultBindings: [{ key: "Mod+g" }],
+    scope: "tasks",
+    defaultWhen: "inBlitzMode",
+    // Holding the chord shouldn't rapidly flip grid on/off.
+    ignoreRepeat: true,
+  },
+  {
+    id: "blitz.grid.exit",
+    name: "Exit Grid Workspace",
+    category: "Blitz",
+    description: "Leave the Blitz grid workspace and return to the task list",
+    defaultBindings: [{ key: "Escape" }],
+    scope: "tasks",
+    // Only while the grid is showing — keeps Escape free for the task list.
+    defaultWhen: "blitzGridActive",
+  },
+];

--- a/grove-web/src/keyboard/types.ts
+++ b/grove-web/src/keyboard/types.ts
@@ -34,6 +34,12 @@ export interface CommandDef {
    * the push-to-talk key after audio.ptt.start fired on keydown).
    */
   trigger?: "keydown" | "keyup";
+  /**
+   * When true, auto-repeat keydowns (key held down) are ignored — the command
+   * fires once per physical press. Use for toggles where holding the key
+   * shouldn't flip state repeatedly (e.g. blitz.grid.toggle).
+   */
+  ignoreRepeat?: boolean;
 }
 
 export type CommandHandler<TArgs = unknown> = (args?: TArgs) => void | Promise<void>;


### PR DESCRIPTION
Follow-up to #18, per your note there ("either way works — just link the two PRs"). This is the **flexlayout-react rewrite** you suggested, opened fresh off current `master` since #18 had drifted into conflict and this is effectively a rewrite. **Supersedes and closes #18.**

## What changed vs the preset grid in #18

- Each pinned chat is a **panel/tab** you can split, resize, rearrange, add, and close — no more fixed 1/2/2×2/3×2 presets. Layout + which chats are pinned **persist to localStorage**, and existing preset grids **migrate in** on first load.
- **Drag a task from the left list onto the canvas** → a placeholder drops where you aim → pick one of its sessions → it becomes a live chat. Gives the left list a real job in grid mode and removes the duplicate task list.
- **Equalize** button + column presets to snap panels even; a `project · task · chat` breadcrumb per panel.
- **Cmd/Ctrl+G** and **Escape** are now rebindable **catalog commands** (`blitz.grid.toggle` / `blitz.grid.exit`, gated by a new `blitzGridActive` context key) — in the ⌘/ help, no double-fire with `tasks.escape`. The old shrink-confirm dialog and preset color are gone with the preset UI.
- **Enter submits** the chat while focused in a grid panel.

## Shape

Reuses the existing `FlexLayoutContainer` + the `flexlayout-react` dependency already in the tree — **no new dependencies**. New files: `BlitzFlexWorkspace`, `blitzFlexModel` (model + migration), `ChatPickerDropdown`, `SessionPickerPane`, `useBlitzGrid`. `TaskChat` gains an optional `pinnedChatId` for single-chat panels.

Frontend-only, 15 files. Verified: `tsc -b && vite build` clean, `eslint --max-warnings 0` clean, `CommandRegistry` tests 20/20.

Closes #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)