### PR TITLE
fix(acp): honor chat launch mode when selecting agent channel

### DIFF
--- a/src/api/handlers/acp.rs
+++ b/src/api/handlers/acp.rs
@@ -985,6 +985,7 @@ async fn handle_acp_ws(socket: WebSocket, session_key: String, config: AcpStartC
 /// Error type for ACP handler
 pub enum AcpError {
     NotFound(String),
+    BadRequest(String),
     Internal(String),
 }
 
@@ -992,6 +993,7 @@ impl IntoResponse for AcpError {
     fn into_response(self) -> Response {
         match self {
             AcpError::NotFound(msg) => (StatusCode::NOT_FOUND, msg).into_response(),
+            AcpError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg).into_response(),
             AcpError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response(),
         }
     }

--- a/src/api/handlers/acp.rs
+++ b/src/api/handlers/acp.rs
@@ -1497,6 +1497,16 @@ pub async fn chat_ws_handler(
         .map_err(|e| AcpError::Internal(e.to_string()))?
         .ok_or(AcpError::NotFound("Chat not found".to_string()))?;
 
+    // The raw PTY endpoint owns terminal-mode chats. Accepting one here would
+    // feed a terminal-only binary into the ACP stdio driver and leave the UI
+    // waiting forever for `session_ready`.
+    if chat.launch_mode != "acp" {
+        return Err(AcpError::BadRequest(format!(
+            "chat launch_mode is {:?}, expected 'acp'",
+            chat.launch_mode
+        )));
+    }
+
     // Resolve agent command from the chat's stored agent.
     //
     // Custom Agent (persona) ids resolve to their underlying base_agent here;
@@ -1562,9 +1572,27 @@ pub async fn chat_ws_handler(
     }
 
     let (final_command, final_args) = if let Some(ref rec) = installed_record {
-        let (cmd, base_args) =
-            crate::storage::installed_agents::spawn_for(rec, registry_agent.as_ref())
-                .unwrap_or_else(|| (resolved.command.clone(), resolved.args.clone()));
+        let launch = crate::storage::installed_agents::spawn_for_launch_mode(
+            rec,
+            registry_agent.as_ref(),
+            &chat.launch_mode,
+        );
+        let terminal_channel_selected = rec.selected_install_method
+            == crate::storage::installed_agents::InstallMethod::External
+            && registry_agent
+                .as_ref()
+                .and_then(|agent| agent.terminal_launch.as_ref())
+                .is_some();
+        let (cmd, base_args) = match launch {
+            Some(spawn) => spawn,
+            None if terminal_channel_selected => {
+                return Err(AcpError::Internal(format!(
+                    "agent {:?} has terminal mode selected but no installed ACP channel",
+                    canonical_id
+                )));
+            }
+            None => (resolved.command.clone(), resolved.args.clone()),
+        };
         let mut args = base_args;
         args.extend(rec.args_override.iter().cloned());
         (cmd, args)

--- a/src/storage/installed_agents.rs
+++ b/src/storage/installed_agents.rs
@@ -519,7 +519,9 @@ pub fn spawn_for_launch_mode(
 ) -> Option<(String, Vec<String>)> {
     let external_is_terminal = launch_mode == "acp"
         && rec.selected_install_method == InstallMethod::External
-        && registry_agent.and_then(|agent| agent.terminal_launch.as_ref()).is_some();
+        && registry_agent
+            .and_then(|agent| agent.terminal_launch.as_ref())
+            .is_some();
 
     if !external_is_terminal {
         return spawn_for(rec, registry_agent);

--- a/src/storage/installed_agents.rs
+++ b/src/storage/installed_agents.rs
@@ -499,6 +499,48 @@ pub fn spawn_for(
     }
 }
 
+/// Resolve a runnable channel for a specific chat launch mode.
+///
+/// Most agents use the selected installation channel for ACP directly. The
+/// exception is an External channel paired with `terminal_launch`: that
+/// channel is the bare interactive CLI (Claude today), not an ACP server. An
+/// ACP chat must therefore use one of the record's installed ACP distribution
+/// channels instead of blindly spawning the selected terminal binary.
+///
+/// Installation order is preserved so migrated users retain their previous
+/// ACP channel preference. Invalid/unlaunchable channels are skipped and the
+/// next installed channel is tried. `None` means the requested mode has no
+/// usable channel; callers should surface that rather than falling back to the
+/// terminal CLI and waiting forever for `session_ready`.
+pub fn spawn_for_launch_mode(
+    rec: &InstalledAgent,
+    registry_agent: Option<&crate::storage::agent_registry::RegistryAgent>,
+    launch_mode: &str,
+) -> Option<(String, Vec<String>)> {
+    let external_is_terminal = launch_mode == "acp"
+        && rec.selected_install_method == InstallMethod::External
+        && registry_agent.and_then(|agent| agent.terminal_launch.as_ref()).is_some();
+
+    if !external_is_terminal {
+        return spawn_for(rec, registry_agent);
+    }
+
+    for installation in &rec.installations {
+        if installation.method == InstallMethod::External
+            || installation.status != InstallStatus::Installed
+        {
+            continue;
+        }
+        let mut candidate = rec.clone();
+        candidate.selected_install_method = installation.method;
+        if let Some(spawn) = spawn_for(&candidate, registry_agent) {
+            return Some(spawn);
+        }
+    }
+
+    None
+}
+
 /// Boot-time recovery: any installation stuck in `installing` is a crashed
 /// install attempt. Mark it failed so the user can retry from Marketplace.
 /// Walks every row, updates the JSON-stored installations array in place.
@@ -1189,6 +1231,69 @@ mod tests {
         let picked = agent.selected_installation().unwrap();
         // Falls back to the first installation we DO have.
         assert_eq!(picked.method, InstallMethod::Npx);
+    }
+
+    #[test]
+    fn acp_launch_avoids_external_terminal_channel() {
+        use crate::storage::agent_registry::TerminalLaunch;
+
+        let mut registry = registry_with_npx("claude-acp");
+        registry.agents[0].terminal_launch = Some(TerminalLaunch {
+            cmd: "claude".into(),
+            session_id_arg: "--session-id".into(),
+            resume_arg: "--resume".into(),
+            mcp_config_arg: "--mcp-config".into(),
+        });
+
+        let mut agent = fresh_npx("claude-acp");
+        agent.installations.insert(
+            0,
+            Installation {
+                method: InstallMethod::External,
+                version: String::new(),
+                install_path: Some("/usr/bin/claude".into()),
+                status: InstallStatus::Installed,
+                failure_reason: None,
+                installed_at: Utc::now(),
+            },
+        );
+        agent.selected_install_method = InstallMethod::External;
+
+        let (command, args) =
+            spawn_for_launch_mode(&agent, Some(&registry.agents[0]), "acp").unwrap();
+
+        assert_eq!(command, "npx");
+        assert_eq!(args, vec!["-y", "@example/claude-acp@1.0.0"]);
+    }
+
+    #[test]
+    fn terminal_launch_keeps_selected_external_channel() {
+        use crate::storage::agent_registry::TerminalLaunch;
+
+        let mut registry = registry_with_npx("claude-acp");
+        registry.agents[0].terminal_launch = Some(TerminalLaunch {
+            cmd: "claude".into(),
+            session_id_arg: "--session-id".into(),
+            resume_arg: "--resume".into(),
+            mcp_config_arg: "--mcp-config".into(),
+        });
+
+        let mut agent = fresh_npx("claude-acp");
+        agent.installations.push(Installation {
+            method: InstallMethod::External,
+            version: String::new(),
+            install_path: Some("/usr/bin/claude".into()),
+            status: InstallStatus::Installed,
+            failure_reason: None,
+            installed_at: Utc::now(),
+        });
+        agent.selected_install_method = InstallMethod::External;
+
+        let (command, args) =
+            spawn_for_launch_mode(&agent, Some(&registry.agents[0]), "terminal").unwrap();
+
+        assert_eq!(command, "/usr/bin/claude");
+        assert!(args.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- reject terminal-mode chats at the ACP WebSocket endpoint with a clear 400 response
- when an External terminal channel is selected, route ACP chats through an installed ACP distribution channel instead
- preserve the selected External channel for actual terminal launches
- surface a clear error when no usable ACP channel is installed

## Root cause

The ACP WebSocket handler used the globally selected installation channel without considering the chat's stored launch mode. For agents such as Claude, an External installation is the bare interactive CLI rather than an ACP server. Starting it through the ACP driver never produces session_ready, leaving the chat offline.

## Verification

- cargo fmt --check
- acp_launch_avoids_external_terminal_channel passed
- terminal_launch_keeps_selected_external_channel passed
- full Rust suite: 406 passed, 0 failed
- production validation confirmed Claude and Codex emit session_ready through ACP
