### PR TITLE
fix(projects): fall back to web picker on headless Linux

### DIFF
--- a/src/api/handlers/folder.rs
+++ b/src/api/handlers/folder.rs
@@ -65,6 +65,12 @@ fn response_for(outcome: PickerOutcome) -> Json<BrowseFolderResponse> {
     }
 }
 
+#[cfg(target_os = "linux")]
+fn linux_display_available(display: Option<&str>, wayland_display: Option<&str>) -> bool {
+    display.is_some_and(|value| !value.trim().is_empty())
+        || wayland_display.is_some_and(|value| !value.trim().is_empty())
+}
+
 pub async fn browse_folder() -> Json<BrowseFolderResponse> {
     #[cfg(target_os = "macos")]
     {
@@ -78,6 +84,17 @@ pub async fn browse_folder() -> Json<BrowseFolderResponse> {
 
     #[cfg(target_os = "linux")]
     {
+        // A user service or SSH-hosted Grove instance can have zenity installed
+        // without access to a graphical session. In that case zenity exits 1
+        // with "cannot open display", which is indistinguishable from Cancel
+        // if we only inspect its exit status. Report the native picker as
+        // unavailable so the frontend opens its in-app server folder browser.
+        let display = std::env::var("DISPLAY").ok();
+        let wayland_display = std::env::var("WAYLAND_DISPLAY").ok();
+        if !linux_display_available(display.as_deref(), wayland_display.as_deref()) {
+            return response_for(PickerOutcome::Unavailable);
+        }
+
         // Try zenity first; if it's installed and the user either picked or
         // cancelled via zenity, honour that result. If zenity is missing,
         // fall through to kdialog. kdialog's outcome is final.
@@ -406,5 +423,14 @@ mod tests {
     fn classify_picker_zero_exit_empty_stdout_is_cancelled() {
         let r = classify_picker(Ok(fake_output(true, "   \n")));
         assert_eq!(r, PickerOutcome::Cancelled);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_picker_requires_graphical_display() {
+        assert!(!linux_display_available(None, None));
+        assert!(!linux_display_available(Some(""), Some("  ")));
+        assert!(linux_display_available(Some(":0"), None));
+        assert!(linux_display_available(None, Some("wayland-0")));
     }
 }

--- a/src/api/handlers/folder.rs
+++ b/src/api/handlers/folder.rs
@@ -11,17 +11,21 @@ use crate::api::error::ApiError;
 pub struct BrowseFolderResponse {
     pub path: Option<String>,
     /// `true` when the user dismissed the native dialog. `false` when the
-    /// picker couldn't be spawned at all (e.g. running on a headless host
-    /// without osascript/zenity/kdialog) — the frontend uses this to decide
-    /// whether to fall back to the in-app web picker.
+    /// picker was unavailable — it couldn't be spawned at all (e.g. running
+    /// on a headless host without osascript/zenity/kdialog) or it spawned
+    /// but couldn't reach a graphical session (`DISPLAY` set but stale) —
+    /// the frontend uses this to decide whether to fall back to the in-app
+    /// web picker.
     #[serde(default)]
     pub cancelled: bool,
 }
 
 /// Outcome of trying to invoke a native folder picker. Distinguishes
 /// "user cancelled" (the dialog appeared and was dismissed) from
-/// "unavailable" (the picker binary couldn't be spawned at all) so the
-/// frontend can decide whether to fall back to the web picker.
+/// "unavailable" (the picker binary couldn't be spawned at all, or it
+/// spawned but couldn't reach a graphical session — e.g. `DISPLAY` points
+/// at a dead X server) so the frontend can decide whether to fall back to
+/// the web picker.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum PickerOutcome {
     Picked(String),
@@ -29,15 +33,40 @@ pub(crate) enum PickerOutcome {
     Unavailable,
 }
 
+/// Known stderr signatures emitted when a dialog binary spawns fine but
+/// cannot connect to a graphical session (`DISPLAY`/`WAYLAND_DISPLAY` set
+/// but stale or inaccessible). Matched case-insensitively as substrings:
+/// - GTK / zenity: `Gtk-WARNING **: cannot open display:`,
+///   `Failed to open display`, `Unable to init server`
+/// - Qt / kdialog: `qt.qpa.xcb: could not connect to display`,
+///   `failed to create wl_display`
+fn stderr_indicates_display_failure(stderr: &[u8]) -> bool {
+    const SIGNATURES: [&str; 5] = [
+        "cannot open display",
+        "failed to open display",
+        "unable to init server",
+        "could not connect to display",
+        "failed to create wl_display",
+    ];
+    let stderr = String::from_utf8_lossy(stderr).to_lowercase();
+    SIGNATURES.iter().any(|sig| stderr.contains(sig))
+}
+
 /// Interpret a child-process result: `Err` (binary missing / not spawnable)
-/// is `Unavailable`; `Ok` with non-zero exit (or zero exit but empty stdout)
-/// is `Cancelled`; `Ok` with a non-empty path on stdout is `Picked`.
+/// is `Unavailable`; `Ok` with non-zero exit is `Cancelled` — unless stderr
+/// carries a known display-connection failure, which is `Unavailable` (the
+/// dialog never appeared, so the user never got a chance to cancel); `Ok`
+/// with zero exit but empty stdout is `Cancelled`; `Ok` with a non-empty
+/// path on stdout is `Picked`.
 pub(crate) fn classify_picker(spawn: io::Result<Output>) -> PickerOutcome {
     let output = match spawn {
         Err(_) => return PickerOutcome::Unavailable,
         Ok(o) => o,
     };
     if !output.status.success() {
+        if stderr_indicates_display_failure(&output.stderr) {
+            return PickerOutcome::Unavailable;
+        }
         return PickerOutcome::Cancelled;
     }
     let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -121,7 +150,7 @@ pub async fn browse_folder() -> Json<BrowseFolderResponse> {
         } else {
             zenity
         };
-        return response_for(outcome);
+        response_for(outcome)
     }
 
     #[cfg(target_os = "windows")]
@@ -388,11 +417,15 @@ mod tests {
     }
 
     fn fake_output(success: bool, stdout: &str) -> Output {
+        fake_output_with_stderr(success, stdout, "")
+    }
+
+    fn fake_output_with_stderr(success: bool, stdout: &str, stderr: &str) -> Output {
         use std::os::unix::process::ExitStatusExt;
         Output {
             status: std::process::ExitStatus::from_raw(if success { 0 } else { 1 }),
             stdout: stdout.as_bytes().to_vec(),
-            stderr: Vec::new(),
+            stderr: stderr.as_bytes().to_vec(),
         }
     }
 
@@ -422,6 +455,51 @@ mod tests {
     #[test]
     fn classify_picker_zero_exit_empty_stdout_is_cancelled() {
         let r = classify_picker(Ok(fake_output(true, "   \n")));
+        assert_eq!(r, PickerOutcome::Cancelled);
+    }
+
+    #[test]
+    fn classify_picker_gtk_display_failure_is_unavailable() {
+        // zenity with DISPLAY set but pointing at a dead X server.
+        let r = classify_picker(Ok(fake_output_with_stderr(
+            false,
+            "",
+            "Gtk-WARNING **: 10:15:33.612: cannot open display: :0\n",
+        )));
+        assert_eq!(r, PickerOutcome::Unavailable);
+    }
+
+    #[test]
+    fn classify_picker_qt_display_failure_is_unavailable() {
+        // kdialog under Qt when the X connection is refused.
+        let r = classify_picker(Ok(fake_output_with_stderr(
+            false,
+            "",
+            "qt.qpa.xcb: could not connect to display :0\n",
+        )));
+        assert_eq!(r, PickerOutcome::Unavailable);
+    }
+
+    #[test]
+    fn classify_picker_gtk_init_failure_is_unavailable() {
+        // GTK3 zenity variant: init fails before the display message.
+        let r = classify_picker(Ok(fake_output_with_stderr(
+            false,
+            "",
+            "Unable to init server: Could not connect: Connection refused\n",
+        )));
+        assert_eq!(r, PickerOutcome::Unavailable);
+    }
+
+    #[test]
+    fn classify_picker_nonzero_with_unrelated_stderr_is_cancelled() {
+        // A real user cancel can still write warnings to stderr — those
+        // must not be misread as an unavailable display.
+        let r = classify_picker(Ok(fake_output_with_stderr(
+            false,
+            "",
+            "Gtk-Message: Failed to load module \"canberra-gtk-module\"\n",
+        )));
         assert_eq!(r, PickerOutcome::Cancelled);
     }
 


### PR DESCRIPTION
## Summary

- detect whether DISPLAY or WAYLAND_DISPLAY is available before launching a native Linux folder picker
- report the native picker as unavailable on headless services so the existing in-app folder browser opens
- retain the existing cancellation behavior when a graphical picker is actually available

## Root cause

When zenity is installed but Grove runs without a graphical display, zenity exits nonzero with cannot open display. The backend classified that as a user cancellation, so the frontend intentionally did nothing instead of opening FolderTreePickerDialog.

## Verification

- cargo fmt --check
- linux_picker_requires_graphical_display passed
- full Rust suite: 405 passed, 0 failed
- live headless deployment returns cancelled:false and successfully lists server directories through the folder-list endpoint
