### PR TITLE
feat(tasks): opt-in agent auto-start from the New Task description

### DIFF
--- a/grove-web/src/api/tasks.ts
+++ b/grove-web/src/api/tasks.ts
@@ -42,6 +42,7 @@ interface CreateTaskRequest {
   name: string;
   target?: string;
   notes?: string;
+  start_agent?: boolean;
 }
 
 type TaskFilter = 'active' | 'archived';
@@ -191,11 +192,12 @@ export async function createTask(
   projectId: string,
   name: string,
   target?: string,
-  notes?: string
+  notes?: string,
+  startAgent?: boolean
 ): Promise<TaskResponse> {
   return apiClient.post<CreateTaskRequest, TaskResponse>(
     `/api/v1/projects/${projectId}/tasks`,
-    { name, target, notes }
+    { name, target, notes, start_agent: startAgent }
   );
 }
 

--- a/grove-web/src/components/Tasks/NewTaskDialog.tsx
+++ b/grove-web/src/components/Tasks/NewTaskDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { X, GitBranch, Plus, FileText, ChevronDown, Loader2 } from "lucide-react";
+import { X, GitBranch, Plus, FileText, ChevronDown, Loader2, Zap } from "lucide-react";
 import { Button, Input } from "../ui";
 import { DialogShell } from "../ui/DialogShell";
 import { useProject } from "../../context";
@@ -10,7 +10,7 @@ import { useCommand, useContextKey, useKeyboardScope } from "../../keyboard";
 interface NewTaskDialogProps {
   isOpen: boolean;
   onClose: () => void;
-  onCreate: (name: string, targetBranch: string, notes: string) => void | Promise<void>;
+  onCreate: (name: string, targetBranch: string, notes: string, startAgent: boolean) => void | Promise<void>;
   isLoading?: boolean;
   externalError?: string | null;
 }
@@ -21,6 +21,7 @@ export function NewTaskDialog({ isOpen, onClose, onCreate, isLoading, externalEr
   const [taskName, setTaskName] = useState("");
   const [targetBranch, setTargetBranch] = useState(selectedProject?.currentBranch || "main");
   const [notes, setNotes] = useState("");
+  const [startAgent, setStartAgent] = useState(false);
   const [error, setError] = useState("");
   const [branches, setBranches] = useState<string[]>([]);
   const [showBranchDropdown, setShowBranchDropdown] = useState(false);
@@ -141,13 +142,15 @@ export function NewTaskDialog({ isOpen, onClose, onCreate, isLoading, externalEr
     }
 
     setError("");
-    await onCreate(taskName.trim(), isStudio ? "" : targetBranch, notes.trim());
+    // startAgent only means something with a description to hand the agent.
+    await onCreate(taskName.trim(), isStudio ? "" : targetBranch, notes.trim(), startAgent && notes.trim().length > 0);
   };
 
   const handleClose = () => {
     setTaskName("");
     setTargetBranch(selectedProject?.currentBranch || "main");
     setNotes("");
+    setStartAgent(false);
     setError("");
     setShowBranchDropdown(false);
     setIsDragging(false);
@@ -287,6 +290,32 @@ export function NewTaskDialog({ isOpen, onClose, onCreate, isLoading, externalEr
                       </div>
                     )}
                   </div>
+
+                  {/* Auto-start: hand the notes to an agent as its first
+                      prompt so work begins immediately on task creation.
+                      Only meaningful with a non-empty description. */}
+                  <label
+                    className={`mt-2 flex items-center gap-2 select-none ${
+                      notes.trim()
+                        ? "cursor-pointer text-[var(--color-text)]"
+                        : "cursor-not-allowed text-[var(--color-text-muted)] opacity-60"
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={startAgent && notes.trim().length > 0}
+                      disabled={!notes.trim()}
+                      onChange={(e) => setStartAgent(e.target.checked)}
+                      className="w-3.5 h-3.5 accent-[var(--color-highlight)]"
+                    />
+                    <span className="inline-flex items-center gap-1.5 text-sm">
+                      <Zap className="w-3.5 h-3.5 text-[var(--color-info)]" />
+                      Start agent on these notes
+                    </span>
+                    <span className="text-xs text-[var(--color-text-muted)]">
+                      — injects the description as the first prompt
+                    </span>
+                  </label>
                 </div>
 
                 {/* Target Branch (selectable) — hidden for Studio */}

--- a/grove-web/src/components/Tasks/TasksPage.tsx
+++ b/grove-web/src/components/Tasks/TasksPage.tsx
@@ -379,7 +379,7 @@ export function TasksPage({ initialTaskId, initialChatId, initialViewMode, onNav
 
   // Handle new task creation (Zen-only)
   const handleCreateTask = useCallback(
-    async (name: string, targetBranch: string, notes: string) => {
+    async (name: string, targetBranch: string, notes: string, startAgent: boolean) => {
       if (!selectedProject) return;
       setIsCreating(true);
       setCreateError(null);
@@ -388,7 +388,7 @@ export function TasksPage({ initialTaskId, initialChatId, initialViewMode, onNav
       let createErr: unknown = null;
       try {
         // Create task and get the response
-        taskResponse = await apiCreateTask(selectedProject.id, name, targetBranch, notesArg);
+        taskResponse = await apiCreateTask(selectedProject.id, name, targetBranch, notesArg, startAgent);
       } catch (err: unknown) {
         createErr = err;
       }

--- a/src/agent_graph/tools.rs
+++ b/src/agent_graph/tools.rs
@@ -1052,6 +1052,69 @@ pub async fn deliver_user_remind(
     }
 }
 
+/// Deliver a user-authored kickoff prompt to a chat, spawning the agent
+/// subprocess first if it isn't running. Used by task auto-start
+/// (`tasks/crud.rs`): the task's notes become the chat's first prompt so the
+/// agent begins working without anyone opening the chat. Mirrors the
+/// automations executor's injection (idle → `send_prompt`, busy →
+/// `queue_message`); no `sender` tag — the prompt renders as a normal user
+/// message, which is what it semantically is.
+pub(crate) async fn deliver_user_kickoff(
+    project_key: &str,
+    task_id: &str,
+    target_chat_id: &str,
+    prompt: String,
+) -> std::result::Result<(), String> {
+    let target_handle = ensure_target_handle(project_key, task_id, target_chat_id)
+        .await
+        .map_err(|e| format!("ensure session: {}", e))?;
+
+    let snapshot = target_handle.snapshot_config();
+    // Atomically claim the busy slot (same race note as `deliver_to_session`):
+    // idle → send directly, busy → visible queue entry drained at end of turn.
+    let claimed = target_handle
+        .is_busy
+        .compare_exchange(
+            false,
+            true,
+            std::sync::atomic::Ordering::AcqRel,
+            std::sync::atomic::Ordering::Acquire,
+        )
+        .is_ok();
+    if !claimed {
+        let messages = target_handle.queue_message(QueuedMessage::new(
+            prompt,
+            Vec::new(),
+            None,
+            false,
+            Some(snapshot),
+        ));
+        target_handle.emit(AcpUpdate::QueueUpdate { messages });
+        return Ok(());
+    }
+
+    let send_res = tokio::time::timeout(
+        Duration::from_secs(10),
+        target_handle.send_prompt(prompt, Vec::new(), None, false, Some(snapshot)),
+    )
+    .await;
+    match send_res {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => {
+            target_handle
+                .is_busy
+                .store(false, std::sync::atomic::Ordering::Release);
+            Err(format!("send_prompt: {}", e))
+        }
+        Err(_) => {
+            target_handle
+                .is_busy
+                .store(false, std::sync::atomic::Ordering::Release);
+            Err("send_prompt timeout (10s)".to_string())
+        }
+    }
+}
+
 /// Ensure an ACP session handle exists for `target_chat_id` — returning the
 /// running handle if it's already up, otherwise synchronously spawning the
 /// agent subprocess for that chat record and waiting for `SessionReady` (with

--- a/src/api/handlers/acp.rs
+++ b/src/api/handlers/acp.rs
@@ -1110,16 +1110,16 @@ pub async fn list_chats(
     }))
 }
 
-/// Create a new chat for a task
-pub async fn create_chat(
-    Path((project_id, task_id)): Path<(String, String)>,
-    Json(body): Json<CreateChatRequest>,
-) -> Result<Json<ChatSessionResponse>, AcpError> {
-    let (project_key, _, _) = resolve_project_key(&project_id)?;
-    let _ = tasks::get_task(&project_key, &task_id)
-        .map_err(|e| AcpError::Internal(e.to_string()))?
-        .ok_or(AcpError::NotFound("Task not found".to_string()))?;
-
+/// Build and persist a chat session on a task, applying the same agent
+/// defaulting, canonicalization, and launch-mode snapshotting as the
+/// `create_chat` HTTP handler. Shared with task auto-start
+/// (`tasks/crud.rs`) so both entry points produce identical chat rows.
+pub(crate) fn create_chat_session_row(
+    project_key: &str,
+    task_id: &str,
+    agent: Option<String>,
+    title: Option<String>,
+) -> Result<tasks::ChatSession, String> {
     let cfg = config::load_config();
     // Resolve to canonical id BEFORE any installed_agents / registry
     // lookup. Legacy ids on disk (older chats / configs) and the
@@ -1127,7 +1127,7 @@ pub async fn create_chat(
     // rows (`claude` → `claude-acp` etc.). The chat row is also persisted
     // with the canonical id so future reads stay consistent.
     let agent =
-        crate::storage::installed_agents::canonicalize_agent_id(&body.agent.unwrap_or_else(|| {
+        crate::storage::installed_agents::canonicalize_agent_id(&agent.unwrap_or_else(|| {
             cfg.acp
                 .agent_command
                 .clone()
@@ -1170,9 +1170,7 @@ pub async fn create_chat(
         }
     };
     let now = chrono::Utc::now();
-    let title = body
-        .title
-        .unwrap_or_else(|| format!("New Chat {}", now.format("%Y-%m-%d %H:%M")));
+    let title = title.unwrap_or_else(|| format!("New Chat {}", now.format("%Y-%m-%d %H:%M")));
 
     let chat = tasks::ChatSession {
         id: tasks::generate_chat_id(),
@@ -1184,8 +1182,22 @@ pub async fn create_chat(
         launch_mode,
     };
 
-    tasks::add_chat_session(&project_key, &task_id, chat.clone())
-        .map_err(|e| AcpError::Internal(e.to_string()))?;
+    tasks::add_chat_session(project_key, task_id, chat.clone()).map_err(|e| e.to_string())?;
+    Ok(chat)
+}
+
+/// Create a new chat for a task
+pub async fn create_chat(
+    Path((project_id, task_id)): Path<(String, String)>,
+    Json(body): Json<CreateChatRequest>,
+) -> Result<Json<ChatSessionResponse>, AcpError> {
+    let (project_key, _, _) = resolve_project_key(&project_id)?;
+    let _ = tasks::get_task(&project_key, &task_id)
+        .map_err(|e| AcpError::Internal(e.to_string()))?
+        .ok_or(AcpError::NotFound("Task not found".to_string()))?;
+
+    let chat = create_chat_session_row(&project_key, &task_id, body.agent, body.title)
+        .map_err(AcpError::Internal)?;
 
     crate::api::handlers::walkie_talkie::broadcast_radio_event(
         crate::api::handlers::walkie_talkie::RadioEvent::ChatListChanged {

--- a/src/api/handlers/tasks/crud.rs
+++ b/src/api/handlers/tasks/crud.rs
@@ -229,6 +229,57 @@ pub async fn create_task(
     use crate::api::handlers::walkie_talkie::{broadcast_radio_event, RadioEvent};
     broadcast_radio_event(RadioEvent::GroupChanged);
 
+    // Auto-start: create a chat on the new task and inject the notes as its
+    // first prompt, so the agent begins working on the description without
+    // anyone opening the chat. The chat row is created synchronously (the UI
+    // navigating into the task sees it immediately); the spawn + prompt
+    // delivery runs in the background because `ensure_target_handle` blocks
+    // on the agent subprocess reaching SessionReady — several seconds we
+    // don't want on the create-task request. A delivery failure logs and
+    // leaves an ordinary empty chat behind; task creation itself already
+    // succeeded and must not be rolled back over a spawn problem.
+    if req.start_agent {
+        let prompt = req.notes.as_ref().filter(|n| !n.trim().is_empty()).cloned();
+        if let Some(prompt) = prompt {
+            match crate::api::handlers::acp::create_chat_session_row(
+                &project_key,
+                &result.task.id,
+                req.agent.clone(),
+                None,
+            ) {
+                Ok(chat) => {
+                    broadcast_radio_event(RadioEvent::ChatListChanged {
+                        project_id: id.clone(),
+                        task_id: result.task.id.clone(),
+                    });
+                    let project_key = project_key.clone();
+                    let task_id = result.task.id.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = crate::agent_graph::tools::deliver_user_kickoff(
+                            &project_key,
+                            &task_id,
+                            &chat.id,
+                            prompt,
+                        )
+                        .await
+                        {
+                            eprintln!(
+                                "[tasks] auto-start kickoff failed for task {} chat {}: {}",
+                                task_id, chat.id, e
+                            );
+                        }
+                    });
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[tasks] auto-start chat creation failed for task {}: {}",
+                        result.task.id, e
+                    );
+                }
+            }
+        }
+    }
+
     Ok(Json(TaskResponse {
         id: result.task.id.clone(),
         name: result.task.name.clone(),

--- a/src/api/handlers/tasks/types.rs
+++ b/src/api/handlers/tasks/types.rs
@@ -86,6 +86,16 @@ pub struct CreateTaskRequest {
     pub target: Option<String>,
     #[serde(default)]
     pub notes: Option<String>,
+    /// When true (and `notes` is non-empty), auto-create a chat session on
+    /// the new task and inject the notes as its first prompt — the agent
+    /// starts working on the description immediately instead of sitting
+    /// idle until someone opens the chat.
+    #[serde(default)]
+    pub start_agent: bool,
+    /// Agent for the auto-started chat. Defaults exactly like chat
+    /// creation: `acp.agent_command` from config, else `claude-acp`.
+    #[serde(default)]
+    pub agent: Option<String>,
 }
 
 /// Rename task request
@@ -526,4 +536,30 @@ pub struct MentionCandidatesResponse {
     pub agents: Vec<MentionAgent>,
     pub outgoing: Vec<MentionOutgoing>,
     pub pending_replies: Vec<MentionPendingReply>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The auto-start fields are opt-in extras on a stable public request —
+    // existing clients that send only {name, target, notes} must keep
+    // deserializing with start_agent=false / agent=None.
+    #[test]
+    fn create_task_request_defaults_without_auto_start_fields() {
+        let req: CreateTaskRequest =
+            serde_json::from_str(r#"{"name":"t1","target":"main","notes":"do it"}"#).unwrap();
+        assert!(!req.start_agent);
+        assert!(req.agent.is_none());
+    }
+
+    #[test]
+    fn create_task_request_parses_auto_start_fields() {
+        let req: CreateTaskRequest = serde_json::from_str(
+            r#"{"name":"t1","notes":"fix the bug","start_agent":true,"agent":"claude-acp"}"#,
+        )
+        .unwrap();
+        assert!(req.start_agent);
+        assert_eq!(req.agent.as_deref(), Some("claude-acp"));
+    }
 }


### PR DESCRIPTION
## What

Opt-in auto-start for new tasks: check **"Start agent on these notes"** in the New Task dialog and the task's description is handed to an agent as its first prompt the moment the task is created — the agent starts working immediately instead of sitting idle until someone opens the chat.

Filling in a description and getting to work is the single most common task-creation flow; today it takes create → open chat → paste/retype the description → send. This makes it one checkbox.

## How

Deliberately thin — it reuses the two existing "start an agent on a chat" mechanisms rather than inventing a third:

- `CreateTaskRequest` gains `start_agent: bool` + `agent: Option<String>` (both `#[serde(default)]` — existing clients are unaffected; covered by serde tests).
- Chat creation is factored out of the `create_chat` handler into `create_chat_session_row(...)` and shared, so auto-started chats get identical agent defaulting / canonicalization / launch-mode snapshotting to UI-created ones.
- Prompt delivery is a new `deliver_user_kickoff(...)` in `agent_graph/tools.rs` mirroring the automations executor's injection: `ensure_target_handle` (spawn-on-demand, waits for `SessionReady`) → CAS on `is_busy` → idle ? `send_prompt` : `queue_message` + `QueueUpdate`. No `sender` tag — the notes render as a normal user message, which is what they semantically are.
- The chat row is created synchronously (the UI navigating into the new task sees it immediately); spawn + delivery run in a background `tokio::spawn` so the create-task request doesn't block on agent startup. Delivery failure logs and degrades to an ordinary empty chat — task creation is never rolled back over a spawn problem.
- Frontend: checkbox in `NewTaskDialog` (disabled until notes are non-empty), threaded through `TasksPage` → `createTask`.

## Notes

- The background kickoff can race the UI's chat-WS connect to spawn the session; both paths funnel through `acp::get_or_start_session` on the same session key — the same surface automations already exercise when a user opens an automation-targeted chat mid-run.
- Studio tasks: the checkbox works there too (notes → first prompt), same delivery path.

## Testing

- `cargo test` (all pass, incl. 2 new serde-contract tests for the request)
- `cargo fmt` / `clippy` clean (no new diagnostics)
- `pnpm eslint` + `pnpm run build` clean
- Manual: task created with notes + toggle → chat appears immediately, agent spawns, notes arrive as first prompt with no browser attached to the chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UArMynjgx3GkKpLzEmR9jR
