### PR TITLE
fix(extension): fall back to the web picker when the companion installer's native dialog cannot open

### DIFF
--- a/grove-web/src/api/extension.ts
+++ b/grove-web/src/api/extension.ts
@@ -88,8 +88,22 @@ export async function revealCompanionPath(
 
 /**
  * Pop a native OS folder picker so the user can choose where to install
- * the companion. Resolves with `path: null` when the user cancels.
+ * the companion.
+ *
+ * Three outcomes, matching `/api/v1/browse-folder`:
+ *   - `{ path: "/abs/path" }`            user picked a folder
+ *   - `{ path: null, cancelled: true }`  user dismissed the dialog
+ *   - `{ path: null, cancelled: false }` no native picker could be shown
+ *
+ * The last case means the server is headless or its DISPLAY is stale, so the
+ * caller should open the in-app folder browser rather than treat it as a
+ * cancel.
  */
-export async function browseInstallFolder(): Promise<{ path: string | null }> {
-  return apiClient.get<{ path: string | null }>('/api/v1/extension/browse-install-folder');
+export async function browseInstallFolder(): Promise<{
+  path: string | null;
+  cancelled?: boolean;
+}> {
+  return apiClient.get<{ path: string | null; cancelled?: boolean }>(
+    '/api/v1/extension/browse-install-folder',
+  );
 }

--- a/grove-web/src/components/Config/InstallExtensionDialog.tsx
+++ b/grove-web/src/components/Config/InstallExtensionDialog.tsx
@@ -1,11 +1,16 @@
 /**
  * Install Chrome Companion — 2-step wizard.
  *
- * Step 1: "Choose Folder & Install" — user picks a directory via native
- *         OS folder picker, backend unpacks the embedded companion into
- *         that path, then launches the user's default browser on
- *         chrome://extensions/ (Chromium browsers forward to their own
- *         protocol automatically).
+ * Step 1: "Choose Folder & Install". User picks a directory, backend
+ *         unpacks the embedded companion into that path, then launches the
+ *         user's default browser on chrome://extensions/ (Chromium browsers
+ *         forward to their own protocol automatically).
+ *
+ *         The directory normally comes from the server's native OS folder
+ *         picker. That picker is unusable when the browser is on a different
+ *         machine (the dialog would open on the server's desktop) or when the
+ *         server is headless, so both cases fall back to the in-app
+ *         FolderTreePickerDialog.
  *
  * Step 2: "Load Unpacked" — always shows the chosen install path with
  *         click-to-copy and a "Reveal in Finder" button, plus three short
@@ -39,6 +44,7 @@ import {
   browseInstallFolder,
   getExtensionStatus,
 } from "../../api/extension";
+import { FolderTreePickerDialog } from "../Projects/FolderTreePickerDialog";
 
 interface Props {
   /** Parent should mount with `{open && <InstallExtensionDialog ... />}`.
@@ -57,6 +63,8 @@ export function InstallExtensionDialog({ onClose }: Props) {
   const [chromeWarning, setChromeWarning] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [revealError, setRevealError] = useState<string | null>(null);
+  // In-app folder browser, used when the native picker cannot be shown.
+  const [pickerOpen, setPickerOpen] = useState(false);
   // Extension connection — fetched on dialog mount only. No polling. If the
   // user plugs in the extension AFTER opening this dialog, closing + reopening
   // the dialog refreshes the badge (the parent conditionally mounts us).
@@ -67,25 +75,23 @@ export function InstallExtensionDialog({ onClose }: Props) {
     return () => { cancelled = true; };
   }, []);
 
-  const handleInstall = async () => {
+  // `window.__GROVE_REMOTE__` is set by AuthGate when `/api/v1/auth/info`
+  // reports either `remote: true` or `required: true`.
+  const isRemoteMode = (): boolean =>
+    (window as unknown as Record<string, unknown>).__GROVE_REMOTE__ === true;
+
+  // Unpack the companion into `dir`, then best-effort launch the user's
+  // default browser on chrome://extensions/. All Chromium browsers forward
+  // to their own protocol; non-Chromium browsers surface a non-fatal warning
+  // so the user can paste the URL by hand.
+  const installAt = async (dir: string) => {
     setInstalling(true);
     setInstallError(null);
     setChromeWarning(null);
     try {
-      // 1. Pop native folder picker. Cancelled = stay on step 1.
-      const picked = await browseInstallFolder();
-      if (!picked.path) {
-        setInstalling(false);
-        return;
-      }
-      // 2. Unpack the embedded companion into the chosen path.
-      const result = await installCompanion(picked.path);
+      const result = await installCompanion(dir);
       setInstallPath(result.path);
       setStep(2);
-      // 3. Best-effort: launch the user's default browser on
-      //    chrome://extensions/. All Chromium browsers forward to their
-      //    own protocol; non-Chromium browsers surface a non-fatal warning
-      //    so the user can paste the URL by hand.
       try {
         await openChromeExtensions();
       } catch (err) {
@@ -94,6 +100,36 @@ export function InstallExtensionDialog({ onClose }: Props) {
       }
     } catch (err) {
       setInstallError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setInstalling(false);
+    }
+  };
+
+  const handleInstall = async () => {
+    // Browsing from another machine: the native dialog would open on the
+    // server's desktop where the user cannot reach it, so go straight to the
+    // in-app folder browser.
+    if (isRemoteMode()) {
+      setPickerOpen(true);
+      return;
+    }
+    setInstalling(true);
+    setInstallError(null);
+    try {
+      const picked = await browseInstallFolder();
+      if (picked.path) {
+        await installAt(picked.path);
+        return;
+      }
+      if (!picked.cancelled) {
+        // Native dialog unavailable (headless host, or DISPLAY pointing at a
+        // dead session). Open the web picker instead of dead-ending.
+        setPickerOpen(true);
+      }
+      // cancelled === true → user dismissed the native dialog; do nothing.
+    } catch (err) {
+      console.error("Failed to browse install folder:", err);
+      setPickerOpen(true);
     } finally {
       setInstalling(false);
     }
@@ -222,6 +258,24 @@ export function InstallExtensionDialog({ onClose }: Props) {
           )}
         </div>
       </motion.div>
+      {/* The picker portals to document.body, but a portal's events still
+          bubble through the React tree. Without this stopPropagation wrapper
+          a click on the picker (its backdrop especially) would reach the
+          overlay's onClick and close the whole wizard underneath it. */}
+      {pickerOpen && (
+        <div onClick={(e) => e.stopPropagation()}>
+          <FolderTreePickerDialog
+            isOpen={pickerOpen}
+            onClose={() => setPickerOpen(false)}
+            onSelect={(dir) => {
+              setPickerOpen(false);
+              void installAt(dir);
+            }}
+            title="Where to install Grove Companion?"
+            zIndex={210}
+          />
+        </div>
+      )}
     </div>,
     document.body,
   );

--- a/grove-web/src/components/Config/InstallExtensionDialog.tsx
+++ b/grove-web/src/components/Config/InstallExtensionDialog.tsx
@@ -7,10 +7,15 @@
  *         forward to their own protocol automatically).
  *
  *         The directory normally comes from the server's native OS folder
- *         picker. That picker is unusable when the browser is on a different
- *         machine (the dialog would open on the server's desktop) or when the
- *         server is headless, so both cases fall back to the in-app
- *         FolderTreePickerDialog.
+ *         picker. When that picker is merely unavailable (headless host, or
+ *         DISPLAY pointing at a dead session) but the browser still shares a
+ *         filesystem with Grove, install falls back to the in-app
+ *         FolderTreePickerDialog, which browses the SERVER's filesystem.
+ *         That fallback is wrong when the browser is on a different machine
+ *         from Grove (remote/mobile mode) — a server-side path is
+ *         unreachable from the client. In that case, skip the server-side
+ *         install entirely and download the packaged extension straight to
+ *         the client's browser instead, for manual extract + Load Unpacked.
  *
  * Step 2: "Load Unpacked" — always shows the chosen install path with
  *         click-to-copy and a "Reveal in Finder" button, plus three short
@@ -43,6 +48,7 @@ import {
   revealCompanionPath,
   browseInstallFolder,
   getExtensionStatus,
+  getCompanionDownloadUrl,
 } from "../../api/extension";
 import { FolderTreePickerDialog } from "../Projects/FolderTreePickerDialog";
 
@@ -63,8 +69,12 @@ export function InstallExtensionDialog({ onClose }: Props) {
   const [chromeWarning, setChromeWarning] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [revealError, setRevealError] = useState<string | null>(null);
-  // In-app folder browser, used when the native picker cannot be shown.
+  // In-app folder browser, used when the native picker cannot be shown but
+  // the browser still shares a filesystem with Grove (same-host headless).
   const [pickerOpen, setPickerOpen] = useState(false);
+  // True once the remote-mode download flow has produced a file — Step 2
+  // then shows client-side instructions instead of a server install path.
+  const [remoteMode, setRemoteMode] = useState(false);
   // Extension connection — fetched on dialog mount only. No polling. If the
   // user plugs in the extension AFTER opening this dialog, closing + reopening
   // the dialog refreshes the badge (the parent conditionally mounts us).
@@ -105,12 +115,40 @@ export function InstallExtensionDialog({ onClose }: Props) {
     }
   };
 
+  // Remote mode: the browser is on a different machine than Grove, so
+  // neither the native picker nor the in-app FolderTreePickerDialog (both of
+  // which resolve a SERVER-side path) can produce anywhere the client could
+  // actually use — `installCompanion()` would unpack the extension onto a
+  // filesystem the browser can never load unpacked from. Download the
+  // packaged extension straight to the client's own Downloads folder
+  // instead; Step 2 then walks through manual extract + Load Unpacked.
+  const handleRemoteDownload = async () => {
+    setInstalling(true);
+    setInstallError(null);
+    try {
+      const url = await getCompanionDownloadUrl();
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "grove-companion.zip";
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      setRemoteMode(true);
+      setStep(2);
+    } catch (err) {
+      setInstallError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setInstalling(false);
+    }
+  };
+
   const handleInstall = async () => {
     // Browsing from another machine: the native dialog would open on the
-    // server's desktop where the user cannot reach it, so go straight to the
-    // in-app folder browser.
+    // server's desktop where the user cannot reach it, and the in-app
+    // FolderTreePickerDialog would only resolve a server-side path — go
+    // straight to the client-side download instead.
     if (isRemoteMode()) {
-      setPickerOpen(true);
+      await handleRemoteDownload();
       return;
     }
     setInstalling(true);
@@ -123,7 +161,8 @@ export function InstallExtensionDialog({ onClose }: Props) {
       }
       if (!picked.cancelled) {
         // Native dialog unavailable (headless host, or DISPLAY pointing at a
-        // dead session). Open the web picker instead of dead-ending.
+        // dead session) but the browser still shares Grove's filesystem —
+        // open the server-side web picker instead of dead-ending.
         setPickerOpen(true);
       }
       // cancelled === true → user dismissed the native dialog; do nothing.
@@ -206,7 +245,14 @@ export function InstallExtensionDialog({ onClose }: Props) {
               onInstall={handleInstall}
             />
           )}
-          {step === 2 && installPath && (
+          {step === 2 && remoteMode && (
+            <Step2RemoteDownload
+              downloading={installing}
+              error={installError}
+              onRedownload={handleRemoteDownload}
+            />
+          )}
+          {step === 2 && !remoteMode && installPath && (
             <Step2LoadUnpacked
               path={installPath}
               connected={connected}
@@ -476,6 +522,72 @@ function Step2LoadUnpacked({
           </button>
         </div>
       )}
+    </div>
+  );
+}
+
+function Step2RemoteDownload({
+  downloading,
+  error,
+  onRedownload,
+}: {
+  downloading: boolean;
+  error: string | null;
+  onRedownload: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col items-center gap-2 text-center">
+        <Check className="h-8 w-8 text-[var(--color-success)]" />
+        <div className="text-sm font-semibold text-[var(--color-text)]">
+          grove-companion.zip downloaded
+        </div>
+        <div className="mx-auto max-w-[360px] text-xs leading-relaxed text-[var(--color-text-muted)]">
+          Grove and this browser are on different machines, so the extension
+          was downloaded to your own Downloads folder instead of installed on
+          the server. Extract the zip, then load the extracted folder below.
+        </div>
+      </div>
+
+      <ol className="space-y-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-secondary)] px-4 py-3 text-xs">
+        <li className="flex gap-3">
+          <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-[var(--color-bg-tertiary)] text-[10px] font-bold text-[var(--color-text)]">
+            1
+          </span>
+          <span className="text-[var(--color-text)]">
+            Extract <span className="font-mono font-semibold">grove-companion.zip</span> anywhere on this computer.
+          </span>
+        </li>
+        <li className="flex gap-3">
+          <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-[var(--color-bg-tertiary)] text-[10px] font-bold text-[var(--color-text)]">
+            2
+          </span>
+          <span className="text-[var(--color-text)]">
+            Open a new tab to <span className="font-mono font-semibold">chrome://extensions/</span> and
+            toggle <span className="font-mono font-semibold">Developer mode</span> (top-right).
+          </span>
+        </li>
+        <li className="flex gap-3">
+          <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-[var(--color-bg-tertiary)] text-[10px] font-bold text-[var(--color-text)]">
+            3
+          </span>
+          <span className="text-[var(--color-text)]">
+            Click <span className="font-mono font-semibold">Load unpacked</span> and
+            select the extracted folder.
+          </span>
+        </li>
+      </ol>
+
+      {error && <ErrorBanner message={error} />}
+
+      <button
+        type="button"
+        onClick={onRedownload}
+        disabled={downloading}
+        className="self-center text-[11px] text-[var(--color-highlight)] hover:underline disabled:opacity-50"
+      >
+        {downloading ? "Downloading…" : "Download again"}
+      </button>
     </div>
   );
 }

--- a/grove-web/src/components/Projects/FolderTreePickerDialog.tsx
+++ b/grove-web/src/components/Projects/FolderTreePickerDialog.tsx
@@ -12,6 +12,11 @@ interface Props {
   title?: string;
   /** Starting dir. Default: server's $HOME (probed via root). */
   initialPath?: string;
+  /**
+   * Stacking level, forwarded to DialogShell. Raise it when opening this
+   * picker from inside another modal so it sits above that modal's backdrop.
+   */
+  zIndex?: number;
 }
 
 /**
@@ -34,6 +39,7 @@ export function FolderTreePickerDialog({
   onSelect,
   title = "Select Folder",
   initialPath,
+  zIndex,
 }: Props) {
   const [data, setData] = useState<ListFolderResponse | null>(null);
   const [loading, setLoading] = useState(false);
@@ -115,7 +121,7 @@ export function FolderTreePickerDialog({
   const currentName = crumbs.length ? crumbs[crumbs.length - 1].label : "";
 
   return (
-    <DialogShell isOpen={isOpen} onClose={onClose} maxWidth="max-w-2xl">
+    <DialogShell isOpen={isOpen} onClose={onClose} maxWidth="max-w-2xl" zIndex={zIndex}>
       <div className="glass-overlay rounded-2xl overflow-hidden w-full max-w-[95vw]">
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--color-border)]">

--- a/src/api/handlers/extension.rs
+++ b/src/api/handlers/extension.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::api::error::ApiError;
+use crate::api::handlers::folder::{pick_folder, response_for, BrowseFolderResponse};
 use crate::api::state::{ExtensionSession, EXTENSION_SESSION};
 
 static REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -682,87 +683,19 @@ pub async fn reveal_install_path(
 }
 
 /// GET /api/v1/extension/browse-install-folder — pop a native folder picker
-/// so the user can choose where the companion gets installed. Returns
-/// `{ path: <abs path> }` on selection or `{ path: null }` if cancelled.
+/// so the user can choose where the companion gets installed.
 ///
-/// Mirrors `folder::browse_folder` (osascript / zenity / kdialog) but with a
-/// companion-specific prompt — copy-pasting the helper rather than adding
-/// a prompt argument keeps the existing endpoint's signature stable.
-pub async fn browse_install_folder() -> Json<serde_json::Value> {
-    #[cfg(target_os = "macos")]
-    {
-        let output = std::process::Command::new("osascript")
-            .arg("-e")
-            .arg("POSIX path of (choose folder with prompt \"Where to install Grove Companion?\")")
-            .output();
-        if let Ok(output) = output {
-            if output.status.success() {
-                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                if !path.is_empty() {
-                    return Json(json!({ "path": path }));
-                }
-            }
-        }
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        let zenity = std::process::Command::new("zenity")
-            .args([
-                "--file-selection",
-                "--directory",
-                "--title=Where to install Grove Companion?",
-            ])
-            .output();
-        if let Ok(output) = zenity {
-            if output.status.success() {
-                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                if !path.is_empty() {
-                    return Json(json!({ "path": path }));
-                }
-            }
-        }
-        let kdialog = std::process::Command::new("kdialog")
-            .args([
-                "--getexistingdirectory",
-                ".",
-                "--title",
-                "Where to install Grove Companion?",
-            ])
-            .output();
-        if let Ok(output) = kdialog {
-            if output.status.success() {
-                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                if !path.is_empty() {
-                    return Json(json!({ "path": path }));
-                }
-            }
-        }
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        // PowerShell FolderBrowserDialog. The trailing trim removes the
-        // PowerShell-injected newline / CR pair so the path matches what
-        // Chrome's file picker would see.
-        let ps = std::process::Command::new("powershell")
-            .args([
-                "-NoProfile",
-                "-Command",
-                "Add-Type -AssemblyName System.Windows.Forms; $f = New-Object System.Windows.Forms.FolderBrowserDialog; $f.Description = 'Where to install Grove Companion?'; if ($f.ShowDialog() -eq 'OK') { Write-Output $f.SelectedPath }",
-            ])
-            .output();
-        if let Ok(output) = ps {
-            if output.status.success() {
-                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                if !path.is_empty() {
-                    return Json(json!({ "path": path }));
-                }
-            }
-        }
-    }
-
-    Json(json!({ "path": serde_json::Value::Null }))
+/// Shares `folder::pick_folder` with the repo picker, so the response
+/// distinguishes the three outcomes the same way: `{ path }` on selection,
+/// `{ path: null, cancelled: true }` when the user dismissed the dialog, and
+/// `{ path: null, cancelled: false }` when no native picker could be shown
+/// (headless host, or `DISPLAY` set but pointing at a dead session). The
+/// frontend falls back to the in-app folder browser on that last case.
+/// Previously all three outcomes returned a bare `{ path: null }`, so an
+/// unavailable picker was indistinguishable from a cancel and clicking the
+/// button on a remote or headless Grove did nothing at all.
+pub async fn browse_install_folder() -> Json<BrowseFolderResponse> {
+    response_for(pick_folder("Where to install Grove Companion?"))
 }
 
 /// POST /api/v1/extension/open-chrome — launch the user's default browser

--- a/src/api/handlers/folder.rs
+++ b/src/api/handlers/folder.rs
@@ -77,7 +77,7 @@ pub(crate) fn classify_picker(spawn: io::Result<Output>) -> PickerOutcome {
     }
 }
 
-fn response_for(outcome: PickerOutcome) -> Json<BrowseFolderResponse> {
+pub(crate) fn response_for(outcome: PickerOutcome) -> Json<BrowseFolderResponse> {
     match outcome {
         PickerOutcome::Picked(path) => Json(BrowseFolderResponse {
             path: Some(path),
@@ -100,15 +100,36 @@ fn linux_display_available(display: Option<&str>, wayland_display: Option<&str>)
         || wayland_display.is_some_and(|value| !value.trim().is_empty())
 }
 
-pub async fn browse_folder() -> Json<BrowseFolderResponse> {
+/// Dialog titles are interpolated into an AppleScript string literal and a
+/// PowerShell single-quoted string, both of which break on their own quote
+/// character. Drop quotes and backslashes instead of escaping them per
+/// platform: titles are short internal labels, so removing the character is
+/// simpler than three escaping rules and cannot produce a malformed script.
+fn sanitize_prompt(prompt: &str) -> String {
+    prompt
+        .chars()
+        .filter(|c| !matches!(c, '"' | '\'' | '\\'))
+        .collect()
+}
+
+/// Invoke the platform's native folder picker with `prompt` as the dialog
+/// title, returning the raw outcome. Shared by the repo picker and the
+/// companion installer so both classify "cancelled" against "unavailable"
+/// identically; callers wrap it with `response_for`.
+pub(crate) fn pick_folder(prompt: &str) -> PickerOutcome {
+    let prompt = sanitize_prompt(prompt);
+
     #[cfg(target_os = "macos")]
     {
-        response_for(classify_picker(
+        classify_picker(
             Command::new("osascript")
                 .arg("-e")
-                .arg("POSIX path of (choose folder with prompt \"Select Git Repository Folder\")")
+                .arg(format!(
+                    "POSIX path of (choose folder with prompt \"{}\")",
+                    prompt
+                ))
                 .output(),
-        ))
+        )
     }
 
     #[cfg(target_os = "linux")]
@@ -121,7 +142,7 @@ pub async fn browse_folder() -> Json<BrowseFolderResponse> {
         let display = std::env::var("DISPLAY").ok();
         let wayland_display = std::env::var("WAYLAND_DISPLAY").ok();
         if !linux_display_available(display.as_deref(), wayland_display.as_deref()) {
-            return response_for(PickerOutcome::Unavailable);
+            return PickerOutcome::Unavailable;
         }
 
         // Try zenity first; if it's installed and the user either picked or
@@ -132,25 +153,19 @@ pub async fn browse_folder() -> Json<BrowseFolderResponse> {
                 .args([
                     "--file-selection",
                     "--directory",
-                    "--title=Select Git Repository Folder",
+                    &format!("--title={}", prompt),
                 ])
                 .output(),
         );
-        let outcome = if matches!(zenity, PickerOutcome::Unavailable) {
+        if matches!(zenity, PickerOutcome::Unavailable) {
             classify_picker(
                 Command::new("kdialog")
-                    .args([
-                        "--getexistingdirectory",
-                        ".",
-                        "--title",
-                        "Select Git Repository Folder",
-                    ])
+                    .args(["--getexistingdirectory", ".", "--title", &prompt])
                     .output(),
             )
         } else {
             zenity
-        };
-        response_for(outcome)
+        }
     }
 
     #[cfg(target_os = "windows")]
@@ -158,16 +173,23 @@ pub async fn browse_folder() -> Json<BrowseFolderResponse> {
         // Exit non-zero on cancel so classify_picker reports `Cancelled`
         // (a zero-exit / empty-stdout case would also report Cancelled, but
         // making it explicit keeps intent clear and the script future-proof).
-        let script = "Add-Type -AssemblyName System.Windows.Forms; \
-                      $f = New-Object System.Windows.Forms.FolderBrowserDialog; \
-                      $f.Description = 'Select Git Repository Folder'; \
-                      if ($f.ShowDialog() -eq 'OK') { Write-Output $f.SelectedPath } else { exit 1 }";
-        return response_for(classify_picker(
+        let script = format!(
+            "Add-Type -AssemblyName System.Windows.Forms; \
+             $f = New-Object System.Windows.Forms.FolderBrowserDialog; \
+             $f.Description = '{}'; \
+             if ($f.ShowDialog() -eq 'OK') {{ Write-Output $f.SelectedPath }} else {{ exit 1 }}",
+            prompt
+        );
+        return classify_picker(
             Command::new("powershell")
-                .args(["-NoProfile", "-NonInteractive", "-Command", script])
+                .args(["-NoProfile", "-NonInteractive", "-Command", &script])
                 .output(),
-        ));
+        );
     }
+}
+
+pub async fn browse_folder() -> Json<BrowseFolderResponse> {
+    response_for(pick_folder("Select Git Repository Folder"))
 }
 
 // ─── Read File Handler ───────────────────────────────────────────────────────
@@ -501,6 +523,24 @@ mod tests {
             "Gtk-Message: Failed to load module \"canberra-gtk-module\"\n",
         )));
         assert_eq!(r, PickerOutcome::Cancelled);
+    }
+
+    #[test]
+    fn sanitize_prompt_strips_script_breaking_characters() {
+        // A quote in the title would terminate the AppleScript / PowerShell
+        // string literal early and leave a malformed script behind.
+        assert_eq!(
+            sanitize_prompt("Where to install \"Grove\" Companion?"),
+            "Where to install Grove Companion?"
+        );
+        assert_eq!(
+            sanitize_prompt(r"back\slash and 'quote'"),
+            "backslash and quote"
+        );
+        assert_eq!(
+            sanitize_prompt("Select Git Repository Folder"),
+            "Select Git Repository Folder"
+        );
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Problem

Clicking **Choose Folder & Install** in the Chrome Companion wizard can do nothing at all: no picker, no error, no spinner. The button just resets.

`browse_install_folder` copy-pasted the native-picker logic rather than reusing `folder::browse_folder`, so it never picked up the `Cancelled` / `Unavailable` distinction added in #26. Every outcome collapsed to a bare `{"path": null}`, and the wizard reads that as "user cancelled":

```rust
const picked = await browseInstallFolder();
if (!picked.path) { setInstalling(false); return; }   // silently gives up
```

So any host where the native dialog cannot be drawn dead-ends. Two common cases:

1. **Headless / service-managed Grove.** zenity exits 1 with `cannot open display`, indistinguishable from a cancel on exit status alone.
2. **Browser on a different machine from the Grove process.** Even when the dialog opens, it opens on the *server's* desktop, where the person clicking the button cannot see or reach it.

The repo picker already handles both. Only the companion installer was left behind.

## Fix

Extract `folder::pick_folder(prompt)` so both endpoints share one implementation, and return the same `{path, cancelled}` shape from `browse_install_folder`:

| Response | Meaning | Wizard behaviour |
|---|---|---|
| `{path: "/abs"}` | user picked | install there |
| `{path: null, cancelled: true}` | user dismissed | no-op |
| `{path: null, cancelled: false}` | picker unavailable | open in-app `FolderTreePickerDialog` |

The dialog also goes straight to the in-app picker in remote mode (`__GROVE_REMOTE__`), matching `AddProjectDialog`, since a server-side dialog is unreachable there by definition.

Two smaller things the refactor required:

- Titles are interpolated now rather than hardcoded per call site, so `sanitize_prompt` strips the quotes and backslashes that would terminate the AppleScript and PowerShell string literals early.
- `FolderTreePickerDialog` gains an optional `zIndex` (the wizard overlay sits at `z-[200]`, above `DialogShell`'s default 50), and the picker is wrapped in a `stopPropagation` guard. Portal events bubble through the React tree, so a click on the picker backdrop would otherwise reach the wizard overlay's `onClose` and shut it.

## Verification

Reproduced against a real service-managed instance whose unit stripped `DISPLAY`. Before the change the endpoint answered `{"path":null}` instantly and the UI did nothing. After:

```
$ curl -s localhost:PORT/api/v1/extension/browse-install-folder
{"path":null,"cancelled":false}
$ curl -s localhost:PORT/api/v1/browse-folder
{"path":null,"cancelled":false}
```

Both endpoints now agree, so the frontend takes the same fallback for each. With `DISPLAY` restored, the request blocks on a real `zenity --file-selection` dialog as expected.

`cargo test` 486 passed, including a new `sanitize_prompt` case. `cargo fmt --check` and `tsc --noEmit` and `eslint --max-warnings 0` all clean.

Note: `cargo clippy -- -D warnings` reports 3 errors on this branch, all of which reproduce identically on a pristine `upstream/master` checkout (`hooks.rs` x2, plus a collapsible `if` in `open_url_with_default_browser`). None are in code this PR touches.
