### PR TITLE
feat(web): add --remote flag so no-auth grove web knows it's remote

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,7 @@ Reset the histogram before measuring an isolated operation; otherwise the cold-s
 
 - `grove` — Smart start: resumes your last mode
 - `grove tui` — Keyboard-first terminal UI
-- `grove web` — Browser IDE on `http://localhost:3001`
+- `grove web` — Browser IDE on `http://localhost:3001`; `--remote` when published through a reverse proxy/tunnel with no auth of its own, so the frontend knows not to trust server-side native OS dialogs
 - `grove gui` — Native desktop window (requires `--features gui` build)
 - `grove mobile` — LAN access for phone / tablet (HMAC-signed requests); `--private` for localhost-only, `--passkey <key>` for custom secret
 - `grove mcp` — MCP server (stdio) for orchestrator agents

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -38,29 +38,47 @@ pub struct ServerAuth {
     /// Used by the startup banner to warn that the key is ephemeral and
     /// won't survive restarts.
     pub key_is_generated: bool,
+    /// True when the operator has declared this instance is reached from a
+    /// different machine than the one Grove runs on — e.g. `grove web`
+    /// published through a reverse proxy or tunnel (Cloudflare Access,
+    /// Tailscale Funnel, ngrok…) with no HMAC auth of its own. `required`
+    /// alone can't capture this: a no-auth `grove web` always reports
+    /// `required: false` regardless of how it's actually reached. The
+    /// frontend uses `remote || required` to decide whether a server-side
+    /// native OS dialog (folder picker, "reveal in file manager", launching
+    /// the default browser) would even be visible to the person making the
+    /// request. Set via `grove web --remote`.
+    pub remote: bool,
     /// Nonce replay-prevention map: nonce → timestamp (epoch secs).
     used_nonces: Mutex<HashMap<String, i64>>,
 }
 
 impl ServerAuth {
-    /// No authentication (localhost / `grove web`).
-    pub fn no_auth() -> Self {
+    /// No authentication (localhost / `grove web`). `remote` should be true
+    /// when the operator has declared this instance is published for
+    /// access from a different machine (see [`ServerAuth::remote`]).
+    pub fn no_auth(remote: bool) -> Self {
         Self {
             mode: AuthMode::None,
             secret_key: None,
             key_is_generated: false,
+            remote,
             used_nonces: Mutex::new(HashMap::new()),
         }
     }
 
     /// HMAC-SHA256 authentication (`grove mobile`). `is_generated` should be
     /// true when the key came from `generate_secret_key()`, false when the
-    /// user typed it at the interactive prompt.
+    /// user typed it at the interactive prompt. Always network-accessed by
+    /// design, so `remote` is implicitly true — callers don't need to pass
+    /// it (the frontend's `required` check already covers HMAC mode, but
+    /// setting it here keeps `ServerAuth::remote` meaningful on its own).
     pub fn hmac(secret_key: String, is_generated: bool) -> Self {
         Self {
             mode: AuthMode::Hmac,
             secret_key: Some(secret_key),
             key_is_generated: is_generated,
+            remote: true,
             used_nonces: Mutex::new(HashMap::new()),
         }
     }
@@ -258,6 +276,10 @@ pub async fn auth_middleware(
 pub struct AuthInfoResponse {
     pub required: bool,
     pub mode: AuthMode,
+    /// See [`ServerAuth::remote`]. The frontend treats `remote || required`
+    /// as "don't trust server-side native OS dialogs" — this field is what
+    /// actually makes that true for a no-auth `grove web --remote` instance.
+    pub remote: bool,
 }
 
 /// `GET /api/v1/auth/info` — tells the SPA whether auth is required and which mode.
@@ -267,6 +289,7 @@ pub async fn auth_info(
     Json(AuthInfoResponse {
         required: auth.secret_key.is_some(),
         mode: auth.mode,
+        remote: auth.remote,
     })
 }
 

--- a/src/cli/gui.rs
+++ b/src/cli/gui.rs
@@ -466,7 +466,9 @@ pub async fn execute(port: u16, remote_url: Option<String>) {
 
     // Start HTTP server in a background task
     let handle = tokio::spawn(async move {
-        let auth = std::sync::Arc::new(api::auth::ServerAuth::no_auth());
+        // The Tauri desktop window is always local — the webview and the
+        // server it talks to run in the same process on the same machine.
+        let auth = std::sync::Arc::new(api::auth::ServerAuth::no_auth(false));
         let app = api::create_router(None, auth, remote_url_clone);
 
         // Signal that server is ready

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -65,6 +65,17 @@ pub enum Commands {
         /// will be proxied/directed to this URL (e.g. http://192.168.1.5:3001).
         #[arg(long, value_name = "URL")]
         remote_url: Option<String>,
+        /// Declare that this instance is reached from a different machine
+        /// than the one Grove runs on — e.g. published through a reverse
+        /// proxy or tunnel (Cloudflare Access, Tailscale Funnel, ngrok…)
+        /// with no HMAC auth of its own. Without this, a no-auth `grove
+        /// web` has no way to know it's not being accessed locally, so
+        /// server-side native OS dialogs (folder picker, "reveal in file
+        /// manager", launching the default browser) silently act on the
+        /// SERVER's desktop/filesystem instead of falling back to an
+        /// in-app equivalent.
+        #[arg(long)]
+        remote: bool,
     },
     /// Open diff review for a task in the browser
     Diff {
@@ -149,11 +160,13 @@ impl Commands {
                 no_open,
                 dev,
                 remote_url,
+                remote,
             } => Some(LastLaunch::Web {
                 port: *port,
                 no_open: *no_open,
                 dev: *dev,
                 remote_url: remote_url.clone(),
+                remote: *remote,
             }),
             Commands::Mobile {
                 port,
@@ -193,11 +206,13 @@ impl LastLaunch {
                 no_open,
                 dev,
                 remote_url,
+                remote,
             } => Commands::Web {
                 port: *port,
                 no_open: *no_open,
                 dev: *dev,
                 remote_url: remote_url.clone(),
+                remote: *remote,
             },
             LastLaunch::Mobile {
                 port,

--- a/src/cli/web.rs
+++ b/src/cli/web.rs
@@ -6,9 +6,10 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
 
-/// Create a ServerAuth with no auth (grove web mode — no auth required)
-fn no_auth() -> Arc<ServerAuth> {
-    Arc::new(ServerAuth::no_auth())
+/// Create a ServerAuth with no auth (grove web mode — no auth required).
+/// `remote` is the operator's `--remote` flag; see [`ServerAuth::remote`].
+fn no_auth(remote: bool) -> Arc<ServerAuth> {
+    Arc::new(ServerAuth::no_auth(remote))
 }
 
 /// Default port for the web server
@@ -98,15 +99,21 @@ fn find_project_dir() -> Option<PathBuf> {
 /// `window.__GROVE_API_BASE__` injected into `index.html`, so that
 /// `AuthGate` and `apiClient` direct every API call to the remote Grove
 /// server (typically `grove mobile`). The form appears as usual for password input.
-pub async fn execute(port: u16, no_open: bool, dev: bool, remote_url: Option<String>) {
+pub async fn execute(
+    port: u16,
+    no_open: bool,
+    dev: bool,
+    remote_url: Option<String>,
+    remote: bool,
+) {
     if let Some(base_url) = remote_url {
         execute_remote_mode(port, no_open, base_url).await;
     } else if dev {
         // Development mode: run vite dev server + API server
-        execute_dev_mode(port, no_open).await;
+        execute_dev_mode(port, no_open, remote).await;
     } else {
         // Production mode: serve static files
-        execute_prod_mode(port, no_open).await;
+        execute_prod_mode(port, no_open, remote).await;
     }
 }
 
@@ -280,7 +287,7 @@ pub async fn execute_mobile(
 }
 
 /// Run in development mode (Vite dev server + API)
-async fn execute_dev_mode(api_port: u16, no_open: bool) {
+async fn execute_dev_mode(api_port: u16, no_open: bool, remote: bool) {
     let project_dir = find_project_dir();
 
     if project_dir.is_none() {
@@ -338,8 +345,15 @@ async fn execute_dev_mode(api_port: u16, no_open: bool) {
     println!("\nPress Ctrl+C to stop");
 
     // Start API server (blocking) - don't open browser (Vite handles frontend)
-    if let Err(e) =
-        api::start_server("127.0.0.1", api_port, None, false, no_auth(), TlsMode::Off).await
+    if let Err(e) = api::start_server(
+        "127.0.0.1",
+        api_port,
+        None,
+        false,
+        no_auth(remote),
+        TlsMode::Off,
+    )
+    .await
     {
         eprintln!("API server error: {}", e);
     }
@@ -350,7 +364,7 @@ async fn execute_dev_mode(api_port: u16, no_open: bool) {
 }
 
 /// Run in production mode (static files + API)
-async fn execute_prod_mode(port: u16, no_open: bool) {
+async fn execute_prod_mode(port: u16, no_open: bool, remote: bool) {
     // Check for embedded assets first
     let has_embedded = api::has_embedded_assets();
 
@@ -369,7 +383,7 @@ async fn execute_prod_mode(port: u16, no_open: bool) {
                     port,
                     Some(built_dir),
                     open_browser,
-                    no_auth(),
+                    no_auth(remote),
                     TlsMode::Off,
                 )
                 .await
@@ -394,7 +408,7 @@ async fn execute_prod_mode(port: u16, no_open: bool) {
         port,
         static_dir,
         open_browser,
-        no_auth(),
+        no_auth(remote),
         TlsMode::Off,
     )
     .await
@@ -432,7 +446,9 @@ async fn execute_remote_mode(port: u16, no_open: bool, base_url: String) {
     println!("Grove web (remote mode): API target  -> {}", api_base);
 
     // Create the same proxy router used by the GUI mode!
-    let auth = Arc::new(ServerAuth::no_auth());
+    // The frontend served here is a local proxy to a remote Grove server —
+    // the browser reaching THIS instance is presumed local either way.
+    let auth = Arc::new(ServerAuth::no_auth(false));
 
     // Check for embedded or external static assets
     let static_dir = api::find_static_dir();

--- a/src/main.rs
+++ b/src/main.rs
@@ -434,11 +434,12 @@ fn main() -> io::Result<()> {
             no_open,
             dev,
             remote_url,
+            remote,
         } => {
             tokio::runtime::Runtime::new()
                 .expect("Failed to create tokio runtime")
                 .block_on(async {
-                    cli::web::execute(port, no_open, dev, remote_url).await;
+                    cli::web::execute(port, no_open, dev, remote_url, remote).await;
                 });
         }
         Commands::Mobile {

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -181,6 +181,9 @@ pub enum LastLaunch {
         /// API server is started; the frontend connects to this URL instead.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         remote_url: Option<String>,
+        /// See `Commands::Web::remote` (the `--remote` flag).
+        #[serde(default)]
+        remote: bool,
     },
     Mobile {
         #[serde(default = "default_web_port")]


### PR DESCRIPTION
## Problem

`/api/v1/auth/info`'s `remote` field is read by the frontend (`AddProjectDialog.tsx`, `InstallExtensionDialog.tsx`: `info.remote || info.required`) to decide whether server-side native OS dialogs — folder picker, "reveal in file manager", launching the default browser — would even be visible to the person making the request.

But the backend never actually populated it: `AuthInfoResponse` only ever had `required`/`mode`, so `info.remote` was always `undefined` and the check silently degraded to `info.required` alone.

That's fine for `grove mobile` (HMAC auth implies remote), but `grove web` always runs `ServerAuth::no_auth()` and always reports `required: false` — there's no signal at all for the common self-hosted pattern of publishing a no-auth `grove web` through an external auth layer (Cloudflare Access, Tailscale Funnel, ngrok, an nginx reverse proxy with its own auth). In that setup the browser is provably on a different machine than Grove, but the backend can't know that, so it always attempts the native picker.

If the host happens to have a live `DISPLAY` (not merely absent, which already fails fast via the existing headless check), the dialog opens successfully **on the server's own desktop** — invisible to the remote user — and the blocking `Command::output()` call hangs the request indefinitely instead of ever reaching the existing in-app `FolderTreePickerDialog` fallback. Hit this for real running `grove web` behind Cloudflare Access on a VM that also has its own local X session.

## Fix

Add `grove web --remote` so the operator can declare this explicitly. Threads through `ServerAuth::remote` → `AuthInfoResponse::remote`, wired into the existing `--port`/`--no-open`/`--dev`/`--remote-url` flag set, `LastLaunch::Web` persistence, and the `grove` smart-start resume path.

**No frontend changes** — the `remote` check has already been in `AddProjectDialog.tsx`/`InstallExtensionDialog.tsx` since `FolderTreePickerDialog` shipped, it just never received real data from the backend.

Also sets `remote: true` unconditionally in `ServerAuth::hmac()` (`grove mobile`) for consistency, since HMAC mode is always network-accessed by design — `required` already covers this case in the frontend check, but now `ServerAuth::remote` is accurate on its own too.

## Testing

- `cargo test` (521 passed), `cargo fmt --check`, `cargo clippy` (default features — clean on the diff; 3 pre-existing default-features-only lints in untouched files, same as noted on prior PRs)
- Manual smoke test: `grove web --port 39001 --no-open` → `{"required":false,"mode":"none","remote":false}`; `grove web --port 39002 --no-open --remote` → `{"required":false,"mode":"none","remote":true}`